### PR TITLE
Zcs 5593: Create bash script to configure test server before soap execution.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -416,6 +416,9 @@
 		<target name="zm-network-soap-content" description="Copies network related soap data and tests">
 			<mkdir dir="${build.temp.dir}"/>
     		<echo message="Copying network related data and tests..."/>
+			<if><available file="${zm-network-soap-harness.dir}/conf/setup.sh" type="file"/>
+				<then><delete file="./conf/setup.sh"/></then>
+			</if>
     		<if> <available file="${zm-network-soap-harness.dir}" type="dir"/>
       		<then>
         		<copy todir="${build.temp.dir}/data">
@@ -423,6 +426,11 @@
           				<include name="**/*"/>
           			</fileset>
         		</copy>
+      			<copy todir="./conf">
+      				<fileset dir="${zm-network-soap-harness.dir}/conf">
+      					<include name="**/*"/>
+      				</fileset>
+      			</copy>
       		</then>
     		</if>
   	</target>
@@ -435,11 +443,6 @@
     	<copy todir="${build.temp.dir}/data/soapvalidator">
       	<fileset dir="data/soapvalidator" includes="**"/>
     	</copy>
-		<copy todir="./conf">
-			<fileset dir="${zm-network-soap-harness.dir}/c">
-				<include name="**/*"/>
-			</fileset>
-		</copy>
 
   	</target>
     

--- a/build.xml
+++ b/build.xml
@@ -435,6 +435,11 @@
     	<copy todir="${build.temp.dir}/data/soapvalidator">
       	<fileset dir="data/soapvalidator" includes="**"/>
     	</copy>
+		<copy todir="./conf">
+			<fileset dir="${zm-network-soap-harness.dir}/c">
+				<include name="**/*"/>
+			</fileset>
+		</copy>
 
   	</target>
     

--- a/conf/setup.sh
+++ b/conf/setup.sh
@@ -11,7 +11,6 @@ if  [ $? != 0 ]; then
         echo "Error occured while installing/activating license. Kindly install/activate the license manually. "
         exit -1
 fi
-echo "Setting LDAP passwords"
-su - zimbra -c "zmldappasswd -a test123; zmldappasswd -b test123; zmldappasswd -l test123; zmldappasswd -n test123; zmldappasswd -p test123; zmldappasswd -r test123; zmldappasswd zimbra"
+
 echo "Restarting mailbox"
 su - zimbra -c "zmmailboxdctl restart"

--- a/conf/setup.sh
+++ b/conf/setup.sh
@@ -1,0 +1,12 @@
+echo "Copying commercial cert for installation"
+mkdir /tmp/commercial
+cp /opt/qa/soapvalidator/conf/commercial/* /opt/zimbra/ssl/zimbra/commercial/
+cp /opt/qa/soapvalidator/conf/commercial/* /tmp/commercial/
+echo "Enabling unauth pings"
+su - zimbra -c "zmlocalconfig -e allow_unauthed_ping=true"
+echo "Installing and activating license"
+su - zimbra -c "zmlicense -i /tmp/regular.xml|zmlicense -a"
+echo "Setting LDAP passwords"
+su - zimbra -c "zmldappasswd -a test123; zmldappasswd -b test123; zmldappasswd -l test123; zmldappasswd -n test123; zmldappasswd -p test123; zmldappasswd -r test123; zmldappasswd zimbra"
+echo "Restarting mailbox"
+su - zimbra -c "zmmailboxdctl restart"

--- a/conf/setup.sh
+++ b/conf/setup.sh
@@ -1,11 +1,16 @@
-echo "Copying commercial cert for installation"
-mkdir /tmp/commercial
-cp /opt/qa/soapvalidator/conf/commercial/* /opt/zimbra/ssl/zimbra/commercial/
-cp /opt/qa/soapvalidator/conf/commercial/* /tmp/commercial/
+if [ "$(whoami)" != "root" ]; then
+        echo "Script must be run as user: root"
+        exit -1
+fi
 echo "Enabling unauth pings"
 su - zimbra -c "zmlocalconfig -e allow_unauthed_ping=true"
 echo "Installing and activating license"
-su - zimbra -c "zmlicense -i /tmp/regular.xml|zmlicense -a"
+wget --no-check-certificate --no-proxy -O /tmp/regular.xml "http://zimbra-stage-license.eng.zimbra.com/zimbraLicensePortal/QA/LKManager?InstallType=regular&AccountsLimit=-1&ver=2.5"
+su - zimbra -c "zmlicense -i /tmp/regular.xml && zmlicense -a"
+if  [ $? != 0 ]; then
+        echo "Error occured while installing/activating license. Kindly install/activate the license manually. "
+        exit -1
+fi
 echo "Setting LDAP passwords"
 su - zimbra -c "zmldappasswd -a test123; zmldappasswd -b test123; zmldappasswd -l test123; zmldappasswd -n test123; zmldappasswd -p test123; zmldappasswd -r test123; zmldappasswd zimbra"
 echo "Restarting mailbox"


### PR DESCRIPTION
All certificates setup script will be kept in zm-network-soap-harness repository.
If network folder exists then these files will be copied to zm-soap-harness/conf folder and certs can be installed using setup.sh script.