### PR TITLE
Zcs 5587: Modify build process to maintain separate global.properties file for FOSS and Network version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -419,6 +419,9 @@
 			<if><available file="${zm-network-soap-harness.dir}/conf/setup.sh" type="file"/>
 				<then><delete file="./conf/setup.sh"/></then>
 			</if>
+			<if><available file="${zm-network-soap-harness.dir}/conf/global.properties" type="file"/>
+				<then><delete file="./conf/global.properties"/></then>
+			</if>
     		<if> <available file="${zm-network-soap-harness.dir}" type="dir"/>
       		<then>
         		<copy todir="${build.temp.dir}/data">


### PR DESCRIPTION
We will maintain two versions for global.properties file.
FOSS version will be void of properties related to Network features related properties.
And if Network edition of the code being used for testing global.properties file from conf folder will be deleted from FOSS code and it will be replaced by network edition.