### PR TITLE
ZCS-5491:delays to allow indexing

### DIFF
--- a/data/soapvalidator/MailClient/Search/search.browseby.xml
+++ b/data/soapvalidator/MailClient/Search/search.browseby.xml
@@ -108,8 +108,7 @@
 </t:test_case>
 
 
-
-
+<t:delay sec="5"/>  <!-- Allow SOLR time to index data - coz MAILBOX_SOFT_COMMIT_TIME=-Dsolr.mailbox.autoSoftCommit.maxTime=5000 -->
 
 <!-- browseBy tests -->
 <t:test_case testcaseid="BrowseRequest1" type="smoke" >
@@ -239,6 +238,8 @@
                 <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
          </t:response>
         </t:test>
+
+<t:delay sec="5"/>  <!-- Allow SOLR time to index data - coz MAILBOX_SOFT_COMMIT_TIME=-Dsolr.mailbox.autoSoftCommit.maxTime=5000 -->
 
 	<t:test>
 	 <t:request>


### PR DESCRIPTION
BrowseRequest requests fail at time of running, then some of them pass later.
Introducing enough time for Solr to commit to the index appears to fix this for BrowseRequest
by "domains" or "attachments" (although not get by "objects" but that doesn't work at all yet)