### PR TITLE
ZCS-5491:browseBy="objects" returns no hits

### DIFF
--- a/data/soapvalidator/MailClient/Search/search.browseby.xml
+++ b/data/soapvalidator/MailClient/Search/search.browseby.xml
@@ -126,6 +126,7 @@
 </t:test_case>
 
 
+<!-- Zimbra-X currently disables zimlets, so browseBy="objects" will always return an empty list -->
 <t:test_case testcaseid="BrowseRequest2" type="smoke" bugids="4895">
  <t:objective>BrowseRequest: browseBy="objects"</t:objective>
 
@@ -134,7 +135,7 @@
 	   <BrowseRequest xmlns="urn:zimbraMail" browseBy="objects"/>
 	 </t:request>
 	  <t:response>
-		<t:select path="//mail:BrowseResponse/mail:bd"/>
+		<t:select path="//mail:BrowseResponse"/>
 	 </t:response>
 	</t:test>
 


### PR DESCRIPTION
As a result of zimlets being disabled, BrowseRequest with
browseBy="objects" will always return an empty list.  This is because
indexing information is only added if any object handlers find matches
in the text and object handlers come from zimlets, so if there are no
zimlets, there are no object handlers.

Updated test to just check that a response is returned rather than expecting a list entry.