### PR TITLE
Zcs 5871:Fix NPE caused when sortBy attribute is not sent in a Search req for is:unread

### DIFF
--- a/data/soapvalidator/MailClient/Search/Bugs/SortBy_ZCS-3705.xml
+++ b/data/soapvalidator/MailClient/Search/Bugs/SortBy_ZCS-3705.xml
@@ -1,5 +1,4 @@
 <t:tests xmlns:t="urn:zimbraTestHarness">
-
 	<t:property name="server.zimbraAdmin" value="${zimbraServer.name}" />
 	<t:property name="message1.subject" value="Subject1_Unread" />
 	<t:property name="message1.content" value=" content of the Unread Message 1" />
@@ -13,11 +12,8 @@
 	<t:property name="test_account1.password" value="test123" />
 	<t:property name="op.read" value="read" />
 	<t:property name="op.unread" value="!read" />
-
-
-
 	<t:test_case testcaseid="Ping" type="smoke">
-		<t:objective>basic system check	</t:objective>
+		<t:objective>basic system check</t:objective>
 		<t:test id="ping">
 			<t:request>
 				<PingRequest xmlns="urn:zimbraAdmin" />
@@ -26,11 +22,9 @@
 				<t:select path="//admin:PingResponse" />
 			</t:response>
 		</t:test>
-	</t:test_case> 
-
+	</t:test_case>
 	<t:test_case testcaseid="acct1_setup" type="always">
 		<t:objective>create test account</t:objective>
-
 		<t:test id="admin_login" required="true" depends="ping">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAdmin">
@@ -60,15 +54,11 @@
 					set="test_acct.server" />
 			</t:response>
 		</t:test>
-
 		<t:property name="server.zimbraAccount" value="${test_acct.server}" />
-		
-		</t:test_case>
-
+	</t:test_case>
 	<t:test_case testcaseid="send_Test_mails" type="always">
-	
-		<t:objective>Send test mails and mark them as read unread </t:objective>
-
+		<t:objective>Send test mails and mark them as read unread
+		</t:objective>
 		<t:test id="Send_mail1">
 			<t:request>
 				<SendMsgRequest xmlns="urn:zimbraMail">
@@ -82,10 +72,11 @@
 				</SendMsgRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="message1.id" />
+				<t:select path="//mail:SendMsgResponse/mail:m" attr="id"
+					set="message1.id" />
 			</t:response>
 		</t:test>
-		<t:delay msec="5000"/>
+		<t:delay msec="5000" />
 		<t:test id="Send_mail2">
 			<t:request>
 				<SendMsgRequest xmlns="urn:zimbraMail">
@@ -99,10 +90,11 @@
 				</SendMsgRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="message2.id" />
+				<t:select path="//mail:SendMsgResponse/mail:m" attr="id"
+					set="message2.id" />
 			</t:response>
 		</t:test>
-		<t:delay msec="5000"/>
+		<t:delay msec="5000" />
 		<t:test id="Send_mail3">
 			<t:request>
 				<SendMsgRequest xmlns="urn:zimbraMail">
@@ -119,7 +111,7 @@
 				<t:select path="//mail:SendMsgResponse/mail:m" attr="id" />
 			</t:response>
 		</t:test>
-		<t:delay msec="5000"/>
+		<t:delay msec="5000" />
 		<t:test id="Send_mail4">
 			<t:request>
 				<SendMsgRequest xmlns="urn:zimbraMail">
@@ -133,10 +125,10 @@
 				</SendMsgRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="message4.id" />
+				<t:select path="//mail:SendMsgResponse/mail:m" attr="id"
+					set="message4.id" />
 			</t:response>
 		</t:test>
-
 		<t:test id="auth" required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -148,9 +140,7 @@
 				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
 			</t:response>
 		</t:test>
-
-		<t:delay msec="5000"/>
-		
+		<t:delay msec="5000" />
 		<t:test>
 			<t:request id="Search_mail3">
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
@@ -158,10 +148,10 @@
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m" attr="id" set="message3.id" />
+				<t:select path="//mail:SearchResponse/mail:m" attr="id"
+					set="message3.id" />
 			</t:response>
 		</t:test>
-
 		<t:test id="Mark_as_read1">
 			<t:request>
 				<MsgActionRequest xmlns="urn:zimbraMail">
@@ -169,14 +159,13 @@
 				</MsgActionRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:MsgActionResponse/mail:action" attr="op" match="${op.read}" />
-				<t:select path="//mail:MsgActionResponse/mail:action" attr="id" match="${message3.id}" />
+				<t:select path="//mail:MsgActionResponse/mail:action" attr="op"
+					match="${op.read}" />
+				<t:select path="//mail:MsgActionResponse/mail:action" attr="id"
+					match="${message3.id}" />
 			</t:response>
 		</t:test>
-
-
-		<t:delay msec="5000"/>
-
+		<t:delay msec="5000" />
 		<t:test id="Search_mail4">
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
@@ -184,10 +173,10 @@
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m" attr="id" set="message4.id" />
+				<t:select path="//mail:SearchResponse/mail:m" attr="id"
+					set="message4.id" />
 			</t:response>
 		</t:test>
-
 		<t:test id="Mark_as_read2">
 			<t:request>
 				<MsgActionRequest xmlns="urn:zimbraMail">
@@ -195,16 +184,15 @@
 				</MsgActionRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:MsgActionResponse/mail:action" attr="op" match="${op.read}" />
-				<t:select path="//mail:MsgActionResponse/mail:action" attr="id" match="${message4.id}" />
+				<t:select path="//mail:MsgActionResponse/mail:action" attr="op"
+					match="${op.read}" />
+				<t:select path="//mail:MsgActionResponse/mail:action" attr="id"
+					match="${message4.id}" />
 			</t:response>
 		</t:test>
-
 	</t:test_case>
-
 	<t:test_case testcaseid="readAsc" type="always">
 		<t:objective>Sort mails by readAsc</t:objective>
-
 		<t:test id="readAsc.test">
 			<t:request>
 				<SearchRequest types="message" sortBy="readAsc" xmlns="urn:zimbraMail">
@@ -212,19 +200,19 @@
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m[1]//mail:su" match="${message4.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[2]//mail:su" match="${message3.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[3]//mail:su" match="${message2.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[4]//mail:su" match="${message1.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[1]//mail:su"
+					match="${message4.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[2]//mail:su"
+					match="${message3.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[3]//mail:su"
+					match="${message2.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[4]//mail:su"
+					match="${message1.subject}" />
 			</t:response>
 		</t:test>
-
 	</t:test_case>
-	
 	<t:test_case testcaseid="readDesc" type="always">
-
 		<t:objective>Sort mails by readDesc</t:objective>
-
 		<t:test id="readDesc.test">
 			<t:request>
 				<SearchRequest types="message" sortBy="readDesc"
@@ -233,25 +221,27 @@
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m[1]//mail:su" match="${message2.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[2]//mail:su" match="${message1.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[3]//mail:su" match="${message4.subject}" />
-				<t:select path="//mail:SearchResponse/mail:m[4]//mail:su" match="${message3.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[1]//mail:su"
+					match="${message2.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[2]//mail:su"
+					match="${message1.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[3]//mail:su"
+					match="${message4.subject}" />
+				<t:select path="//mail:SearchResponse/mail:m[4]//mail:su"
+					match="${message3.subject}" />
 			</t:response>
 		</t:test>
 	</t:test_case>
-
-	<t:test_case testcaseid="Verify_Scrolldown_Error" type="smoke" bugids="ZBUG-425, ZBUG-563">
-		<t:objective>To verify no exception is thrown on scrolling to the end of the search results when results are sorted by read/unread
+	<t:test_case testcaseid="Verify_Scrolldown_Error" type="smoke"
+		bugids="ZBUG-425, ZBUG-563">
+		<t:objective>To verify no exception is thrown on scrolling to the end
+			of the search results when results are sorted by read/unread
 		</t:objective>
-
-		<t:steps>
-			1. Log in with account 1.
-			2. Search first 2 messages and get id of the last message.
-			3. Search next 2 messages and pass cursor element with id of the last message.
-			4. Verify exception is not thrown in the search response.
+		<t:steps> 1. Log in with account 1. 2. Search first 2 messages and get
+			id of the last message. 3. Search next 2 messages and pass cursor
+			element with id of the last message. 4. Verify exception is not
+			thrown in the search response.
 		</t:steps>
-
 		<t:test id="auth" required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -263,21 +253,22 @@
 				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readAsc.test">
 			<t:request>
-				<SearchRequest types="message" sortBy="readAsc" limit="2" offset="0" xmlns="urn:zimbraMail">
+				<SearchRequest types="message" sortBy="readAsc" limit="2"
+					offset="0" xmlns="urn:zimbraMail">
 					<query xmlns="urn:zimbraMail">in:inbox</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m[2]" attr="id" set="cursor.id" />
+				<t:select path="//mail:SearchResponse/mail:m[2]" attr="id"
+					set="cursor.id" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readAsc.test">
 			<t:request>
-				<SearchRequest types="message" sortBy="readAsc" limit="2" offset="2" xmlns="urn:zimbraMail">
+				<SearchRequest types="message" sortBy="readAsc" limit="2"
+					offset="2" xmlns="urn:zimbraMail">
 					<query xmlns="urn:zimbraMail">in:inbox</query>
 					<cursor id="${cursor.id}" xmlns="urn:zimbraMail" />
 				</SearchRequest>
@@ -286,21 +277,22 @@
 				<t:select path="//mail:SearchResponse" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readDesc.test">
 			<t:request>
-				<SearchRequest types="message" sortBy="readDesc" limit="2" offset="0" xmlns="urn:zimbraMail">
+				<SearchRequest types="message" sortBy="readDesc"
+					limit="2" offset="0" xmlns="urn:zimbraMail">
 					<query xmlns="urn:zimbraMail">in:inbox</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:m[2]" attr="id" set="cursor.id" />
+				<t:select path="//mail:SearchResponse/mail:m[2]" attr="id"
+					set="cursor.id" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readAsc.test">
 			<t:request>
-				<SearchRequest types="message" sortBy="readDesc" limit="2" offset="2" xmlns="urn:zimbraMail">
+				<SearchRequest types="message" sortBy="readDesc"
+					limit="2" offset="2" xmlns="urn:zimbraMail">
 					<query xmlns="urn:zimbraMail">in:inbox</query>
 					<cursor id="${cursor.id}" xmlns="urn:zimbraMail" />
 				</SearchRequest>
@@ -309,68 +301,118 @@
 				<t:select path="//mail:SearchResponse" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readDesc.test.Conv">
 			<t:request>
-				<SearchRequest types="conversation" sortBy="readDesc" needExp="1" recip="0" fullConversation="1" limit="2" offset="0"
+				<SearchRequest types="conversation" sortBy="readDesc"
+					needExp="1" recip="0" fullConversation="1" limit="2" offset="0"
 					xmlns="urn:zimbraMail">
 					<query>in:inbox</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su" match="${message2.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su" match="${message1.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id" set="cursor.id" />
-				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id" set="sortVal" />
+				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su"
+					match="${message2.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su"
+					match="${message1.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id"
+					set="cursor.id" />
+				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id"
+					set="sortVal" />
 				<t:select path="//mail:SearchResponse" attr="more" match="1" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readDesc.test.Conv">
 			<t:request>
-				<SearchRequest types="conversation" sortBy="readDesc" needExp="1" recip="0" fullConversation="1" limit="2" offset="2"
+				<SearchRequest types="conversation" sortBy="readDesc"
+					needExp="1" recip="0" fullConversation="1" limit="2" offset="2"
 					xmlns="urn:zimbraMail">
 					<query>in:inbox</query>
 					<cursor id="${cursor.id}" sortVal="${sortVal}" />
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su" match="${message4.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su" match="${message3.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su"
+					match="${message4.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su"
+					match="${message3.subject}" />
 				<t:select path="//mail:SearchResponse" attr="more" match="0" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readAsc.test.Conv">
 			<t:request>
-				<SearchRequest types="conversation" sortBy="readAsc" needExp="1" recip="0" fullConversation="1" limit="2" offset="0"
+				<SearchRequest types="conversation" sortBy="readAsc"
+					needExp="1" recip="0" fullConversation="1" limit="2" offset="0"
 					xmlns="urn:zimbraMail">
 					<query>in:inbox</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su" match="${message4.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su" match="${message3.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id" set="cursor.id" />
+				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su"
+					match="${message4.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su"
+					match="${message3.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]" attr="id"
+					set="cursor.id" />
 				<t:select path="//mail:SearchResponse" attr="more" match="1" />
 			</t:response>
 		</t:test>
-
 		<t:test id="readAsc.test.Conv">
 			<t:request>
-				<SearchRequest types="conversation" sortBy="readAsc" needExp="1" recip="0" fullConversation="1" limit="2" offset="2"
+				<SearchRequest types="conversation" sortBy="readAsc"
+					needExp="1" recip="0" fullConversation="1" limit="2" offset="2"
 					xmlns="urn:zimbraMail">
 					<query>in:inbox</query>
 					<cursor id="${cursor.id}" sortVal="${sortVal}" />
 				</SearchRequest>
 			</t:request>
 			<t:response>
-				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su" match="${message2.subject}" />
-				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su" match="${message1.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[1]/mail:su"
+					match="${message2.subject}" />
+				<t:select path="//mail:SearchResponse/mail:c[2]/mail:su"
+					match="${message1.subject}" />
 				<t:select path="//mail:SearchResponse" attr="more" match="0" />
 			</t:response>
 		</t:test>
-
-
+	</t:test_case>
+	<t:test_case testcaseid="Verify_IsUnreadWithoutSortBy"
+		type="smoke" bugids="ZCS-5871">
+		<t:objective>To verify no exception is thrown when
+			query=is:unread/read and no sortBy option is provided.
+		</t:objective>
+		<t:steps> 1. Log in with account 1. 2. Search with
+			query='is:unread/read' without sortby option 3. Verify exception is
+			not thrown in the search response.
+		</t:steps>
+		<t:test id="auth" required="true">
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account by="name">${test_account1.name}</account>
+					<password>${test_account1.password}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
+			</t:response>
+		</t:test>
+		<t:test id="is:Unread">
+			<t:request>
+				<SearchRequest types="message" xmlns="urn:zimbraMail">
+					<query xmlns="urn:zimbraMail">is:unread</query>
+				</SearchRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//mail:SearchResponse" />
+			</t:response>
+		</t:test>
+		<t:test id="is:read">
+			<t:request>
+				<SearchRequest types="message" xmlns="urn:zimbraMail">
+					<query xmlns="urn:zimbraMail">is:read</query>
+				</SearchRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//mail:SearchResponse" />
+			</t:response>
+		</t:test>
 	</t:test_case>
 </t:tests>


### PR DESCRIPTION
1. Corrected indentation
2. Added one more test case to verify searchResponse for query 'is:unread/read' when sortby option is not provided.

Automation report can be verified below : 
[SortBy_ZCS-3705.txt](https://github.com/Zimbra/zm-soap-harness/files/2382180/SortBy_ZCS-3705.txt)
