### PR TITLE
ZCS-4785:Added delay before SearchRequest so that SearchResponse becomes available.

### DIFF
--- a/conf/global.properties
+++ b/conf/global.properties
@@ -143,3 +143,4 @@ sync.harness.RestartOutlookInterval=25
 staf.process.timeout.default=180000
 staf.process.timeout.zmmtactl=600000
 staf.process.timeout.zmmailboxdctl=600000
+solrcommitdelay.sec=5

--- a/data/soapvalidator/MailClient/Calendar/Bugs/Bug28615.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/Bug28615.xml
@@ -94,6 +94,8 @@
 		</t:restServletResponse>
 	</t:resttest>
 
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+
     <t:test required="true" >
         <t:request>
 			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-7d)[${ical1.start}]}" calExpandInstEnd="${TIME(+7d)[${ical1.start}]}" types="appointment">
@@ -146,6 +148,8 @@
 			<t:select attr="StatusCode" match="200"/>
 		</t:restServletResponse>
 	</t:resttest>
+  
+ <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
 
     <t:test required="true" >
         <t:request>

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug38478.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug38478.xml
@@ -278,8 +278,10 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
     
-      	<t:test depends="sendInviteReplyRequesta">
+    <t:test>
         <t:request>
             <SearchRequest xmlns="urn:zimbraMail" types="message">
                 <query>(Subject withheld)</query>
@@ -430,8 +432,10 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
     
-      	<t:test depends="sendInviteReplyRequesta">
+    <t:test>
         <t:request>
             <SearchRequest xmlns="urn:zimbraMail" types="message">
                 <query>${appointment1.subject}</query>

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug45757.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug45757.xml
@@ -175,7 +175,8 @@
 
 	<t:property name="server.zimbraAccount" value="${user3.server}"/>
 
-    
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+
     <t:test id="auth1" required="true">
         <t:request>
             <AuthRequest xmlns="urn:zimbraAccount">
@@ -321,9 +322,9 @@
         </t:response>
     </t:test>
 
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
 
-
-     <t:test>
+    <t:test>
         <t:request>
 			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-2d)[${time.20180101120000.gmt}]}" calExpandInstEnd="${TIME(+2d)[${time.20180101120000.gmt}]}" types="appointment">
 				<query>inid:${user3.calendar.folder.id}</query>

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug55317.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug55317.xml
@@ -145,7 +145,7 @@
             <t:select path = "//mail:CreateAppointmentResponse"/>
         </t:response>
     </t:test>
-
+    
     <t:test required="true" >
         <t:request>
             <GetApptSummariesRequest xmlns="urn:zimbraMail" s="${TimeRangeStart}" e="${TimeRangeFinish}"/>
@@ -195,7 +195,9 @@
         <t:response>
            <t:select path = "//mail:SendInviteReplyResponse" attr="apptId" match="${account2_appt1.id}"/>
         </t:response>
-    </t:test>    
+    </t:test>  
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
 
 	<t:property name="server.zimbraAccount" value="${test_acct1.server}"/>
 	
@@ -264,7 +266,9 @@
            <t:select path = "//mail:SendInviteReplyResponse" attr="apptId" match="${account2_appt1.id}"/>
         </t:response>
     </t:test>
-    
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+
     <t:property name="server.zimbraAccount" value="${test_acct1.server}"/>
 	
 	<t:test id="auth1" required="true">

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug59163.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug59163.xml
@@ -86,9 +86,11 @@
 			<t:select attr="StatusCode" match="200"/>
 		</t:restServletResponse>
 	</t:resttest>
-
-    <t:test required="true" >
-        <t:request>
+ 
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+  
+  <t:test required="true" >
+      <t:request>
 			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${ical.start}" calExpandInstEnd="${ical.end}" types="appointment">
 				<query>${ical.subject}</query>
 			</SearchRequest>

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug62674.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug62674.xml
@@ -45,7 +45,18 @@
         </t:response>
     </t:test>
     
-    
+    <!-- Request to get the zimbraMailHost -->
+    <t:test>
+        <t:request>
+            <GetAccountRequest xmlns="urn:zimbraAdmin">
+                    <account by="name">${admin.user}</account>
+            </GetAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:GetAccountResponse/admin:account/admin:a[@n='zimbraMailHost']" set="mailbox.server"/>
+        </t:response>
+    </t:test>
+
         <t:test >
         <t:request>
             <CreateDomainRequest xmlns="urn:zimbraAdmin">
@@ -61,7 +72,7 @@
 
 	<t:test >
         <t:request>
-            <CreateGalSyncAccountRequest xmlns="urn:zimbraAdmin" name="name${TIME}${COUNTER}" type="zimbra" domain="${domain1.name}" server="${server.zimbraAdmin}">
+            <CreateGalSyncAccountRequest xmlns="urn:zimbraAdmin" name="name${TIME}${COUNTER}" type="zimbra" domain="${domain1.name}" server="${mailbox.server}">
         		<account by="name">${domain1.galaccount.name}</account>
     		</CreateGalSyncAccountRequest>
         </t:request>

--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug87690.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug87690.xml
@@ -166,6 +166,8 @@
             <t:select path="//mail:CreateAppointmentResponse" attr="invId" set="appointment1.id"/>
         </t:response>
     </t:test>
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
     
     <t:test>
         <t:request>
@@ -240,8 +242,10 @@
             <t:select path = "//mail:CancelAppointmentResponse"/>
         </t:response>
     </t:test>
+
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
     
-   <t:test>
+    <t:test>
 	<t:request>
 		<FolderActionRequest xmlns="urn:zimbraMail" requestId="0">
 			<action op="check" id="${account2.delegated.id}"/>

--- a/data/soapvalidator/MailClient/Contacts/Bugs/bug77914.xml
+++ b/data/soapvalidator/MailClient/Contacts/Bugs/bug77914.xml
@@ -89,7 +89,9 @@
 			<t:select attr="StatusCode" match="200"/>
 		</t:restServletResponse>
 	</t:resttest>
-	    
+
+	<t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->   
+    
     <t:test>
 		<t:request>
 			<SearchRequest xmlns="urn:zimbraMail" types="contact">

--- a/data/soapvalidator/MailClient/GAL/GALAccount/Resources/SearchGalRequest.xml
+++ b/data/soapvalidator/MailClient/GAL/GALAccount/Resources/SearchGalRequest.xml
@@ -148,6 +148,8 @@
         </t:response>
     </t:test>
 
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+    
     <t:test>
         <t:request>
             <SearchRequest xmlns="urn:zimbraMail" types="contact">
@@ -184,6 +186,8 @@
         </t:response>
     </t:test>
 
+    <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+    
     <t:test id="SearchGal1">
         <t:request>
             <SearchGalRequest xmlns="urn:zimbraAccount">

--- a/data/soapvalidator/MailClient/Mail/Bugs/bug59304.xml
+++ b/data/soapvalidator/MailClient/Mail/Bugs/bug59304.xml
@@ -82,7 +82,8 @@
 		</t:test>
 
 		
-		<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>		<t:mailinjecttest>
+		<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>		
+		<t:mailinjecttest>
         	<t:lmtpInjectRequest>
             	<filename>${msg01.file}</filename>
             	<to>${account1.name}</to>
@@ -90,7 +91,9 @@
             	<server>${account1.server}</server>
         	</t:lmtpInjectRequest>
     	</t:mailinjecttest>
-    	
+  
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->	
+	
 	<t:test>
 		<t:request>
 			<SearchRequest xmlns="urn:zimbraMail" types="message">

--- a/data/soapvalidator/MailClient/Mail/Bugs/bug97339.xml
+++ b/data/soapvalidator/MailClient/Mail/Bugs/bug97339.xml
@@ -98,8 +98,10 @@
 			<server>${account1.server}</server>
         </t:lmtpInjectRequest>
     </t:mailinjecttest>
-
-	<t:test>
+  
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+	
+  <t:test>
 	 <t:request>
 	   <SearchRequest xmlns="urn:zimbraMail" types="message">
 	   <query>subject:testing images with / without base</query>
@@ -129,8 +131,10 @@
 			<server>${account1.server}</server>
         </t:lmtpInjectRequest>
     </t:mailinjecttest>
-
-	<t:test>
+  
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+	
+  <t:test>
 	 <t:request>
 	   <SearchRequest xmlns="urn:zimbraMail" types="message">
 	   <query>subject:test 4</query>

--- a/data/soapvalidator/RestServlet/Calendar/Post/basic.xml
+++ b/data/soapvalidator/RestServlet/Calendar/Post/basic.xml
@@ -115,7 +115,9 @@
 		</t:restServletResponse>
 	</t:resttest>
 
-    <t:test >
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+  
+  <t:test >
         <t:request>
             <GetApptSummariesRequest xmlns="urn:zimbraMail" s="${TIME(-7d)[${ical1.start}]}" e="${TIME(+7d)[${ical1.end}]}"/>
         </t:request>
@@ -125,7 +127,7 @@
             <t:select path="//mail:GetApptSummariesResponse/mail:appt[@name='${ical1.name}']/mail:inst" attr="s" match="${ical1.start}"/>
             <t:select path="//mail:GetApptSummariesResponse/mail:appt[@name='${ical1.name}']/mail:fr" match="${ical1.description}"/>
         </t:response>
-    </t:test>
+   </t:test>
 
 </t:test_case>
 
@@ -167,7 +169,9 @@
 		</t:restServletResponse>
 	</t:resttest>
 
-    <t:test >
+  <t:delay sec="${solrcommitdelay.sec}"/>   <!-- Wait for Solr commit to happen -->
+  
+  <t:test >
         <t:request>
             <GetApptSummariesRequest xmlns="urn:zimbraMail" s="${ical2.start}" e="${ical2.end}"/>
         </t:request>
@@ -175,7 +179,7 @@
             <t:select path="//mail:GetApptSummariesResponse/mail:appt[@name='Pearl Jam']"/>
             <t:select path="//mail:GetApptSummariesResponse/mail:appt[@name='Posted Rental Ad on Craigslist']"/>
         </t:response>
-    </t:test>
+   </t:test>
 
 
 </t:test_case>


### PR DESCRIPTION
As of now Solr commit policy is set as follows:
MAILBOX_SOFT_COMMIT_TIME=-Dsolr.mailbox.autoSoftCommit.maxTime=5000
MAILBOX_SOFT_COMMIT_DOCS=-Dsolr.mailbox.autoSoftCommit.maxDocs=-1

Because of this, SearchResponse is not being returned if we make a SearchRequest immediately after the item creation. Added a delay of 5 secs before SearchRequest for now so that SearchResponse is returned. The amount of delay can be reduced when MAILBOX_SOFT_COMMIT_TIME is reduced.
Add `solrcommitdeplay.sec` in `conf/global.properties` to consider delay as per solr commit policy.

We could not replace SearchRequest with the corresponding get--Request as items is getting created by one account and it is being searched by another account. To get the item ids, we need to make 
a SearchRequest first. 

Fixed test case as _data/soapvalidator/MailClient/Calendar/Bugs/bug62674.xml_ so that CreateGalSyncAccountRequest goes to the mail-host on which this GalSync account would reside. 

Removed test dependency from test 'data/soapvalidator/MailClient/Calendar/Bugs/bug38478.xml' as the there is no such test in the test file to depend on.