### PR TITLE
Deprecated unit tests

### DIFF
--- a/data/soapvalidator/Admin/DevUnitTest/UnitTestRequest.xml
+++ b/data/soapvalidator/Admin/DevUnitTest/UnitTestRequest.xml
@@ -6,7 +6,7 @@
 <t:property name="user4.user" value="user4@${defaultdomain.name}"/>
 <t:property name="zimbra.home.dir" value="/opt/zimbra"/>
 
-<t:test_case testcaseid="UnitTest_Setup" type="always" >
+<t:test_case testcaseid="UnitTest_Setup" type="deprecated" >
     <t:objective>basic system check</t:objective>
 
 	<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>	
@@ -215,7 +215,7 @@
 
 <t:property name="uri" value="${admin.uri}"/>
 
-<t:test_case testcaseid="RunUnitTestsRequest1" type="smoke">
+<t:test_case testcaseid="RunUnitTestsRequest1" type="deprecated">
   <t:objective>Make sure user is not allowed to run unit tests</t:objective>
   
   <!-- Login to user account -->
@@ -245,7 +245,7 @@
 <!-- Do admin auth and run tests -->
 <t:property name="Testdata.folder" value="${testMailRaw.root}/DevUnitTestData"/>
 
-<t:test_case testcaseid="Copy_Unittest_Rawdata" type="always">
+<t:test_case testcaseid="Copy_Unittest_Rawdata" type="deprecated">
     <t:objective>Copy the required unittest raw data </t:objective>
 
     <t:test id="admin_login" required="true">
@@ -307,7 +307,7 @@
 
 </t:test_case>
 
-<t:test_case testcaseid="RunUnitTestsRequest2" type="smoke" bugids="54812">   
+<t:test_case testcaseid="RunUnitTestsRequest2" type="deprecated" bugids="54812">   
     <t:objective>Execute the internal Unit Tests </t:objective>
 
 	<t:test id="runUnitTests">


### PR DESCRIPTION
Removed unit tests as soap run should not execute unit tests.
It should be executed before creating the build