### PR TITLE
ProxySoapHttpTransport diagnostics

### DIFF
--- a/src/java/com/zimbra/qa/soap/ProxySoapHttpTransport.java
+++ b/src/java/com/zimbra/qa/soap/ProxySoapHttpTransport.java
@@ -126,6 +126,7 @@ public class ProxySoapHttpTransport extends com.zimbra.common.soap.SoapTransport
         commonInit(uri);
 
         if (proxyHost != null && proxyHost.length() > 0 && proxyPort > 0) {
+            System.out.println(String.format("Creating %s with proxyHost=%s proxyPort=%s proxyUser=%s", this, proxyHost, proxyPort, proxyUser));
             mClient.getHostConfiguration().setProxy(proxyHost, proxyPort);
             if (proxyUser != null && proxyUser.length() > 0 && proxyPass != null && proxyPass.length() > 0) {
                 mClient.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort), new UsernamePasswordCredentials(proxyUser, proxyPass));
@@ -141,6 +142,7 @@ public class ProxySoapHttpTransport extends com.zimbra.common.soap.SoapTransport
             new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT,
                 AuthScope.ANY_REALM, AuthPolicy.BASIC),
         new UsernamePasswordCredentials(proxyUser, proxyPass));
+        System.out.println(String.format("Creating %s with proxyUser=%s", this, proxyUser));
     }
 
 
@@ -284,7 +286,10 @@ public class ProxySoapHttpTransport extends com.zimbra.common.soap.SoapTransport
                 } catch (HttpRecoverableException e) {
                     if (attempt == mRetryCount - 1)
                         throw e;
-                    System.err.println("A recoverable exception occurred, retrying." + e.getMessage());
+                    System.err.println(String.format("A non-recoverable exception occurred, retrying. %s (%s)", e.getMessage(), this));
+                } catch (Exception e) {
+                    System.err.println(String.format("A non-recoverable exception occurred. %s (%s)", e.getMessage(), this));
+                    throw e;
                 }
             }
 


### PR DESCRIPTION
Gordon ran some initial sanity tests against a Kubernetes cluster using zm-docker-soap kubernetes branch  There were a lot of exceptions in there like the following and I thought it would be useful to actually know which ports/hostnames were being used.
This helped me, yielding:

    A non-recoverable exception occurred. connect timed out (ProxySoapHttpTransport(uri=https://proxy-svc:443/service/soap/))


```
     [java] 16 Nov 2018 17:20:43,828 [soap.SoapTestCore][main] :: ERROR   /opt/soap/zm-soap-harness/data/soapvalidator/SanityTest/AccountRequest_sanity.xml threw an exception   
     [java] com.zimbra.qa.soap.SoapTestCore$HarnessException: Error while running SOAP XML
     [java] 	at com.zimbra.qa.soap.SoapTest.executeSoapXML(SoapTest.java:171)
     [java] 	at com.zimbra.qa.soap.SoapTest.executeTest(SoapTest.java:209)
     [java] 	at com.zimbra.qa.soap.SoapTestCore.doTest(SoapTestCore.java:893)
     [java] 	at com.zimbra.qa.soap.SoapTestCore.doTestCase(SoapTestCore.java:1024)
     [java] 	at com.zimbra.qa.soap.SoapTestCore.doTests(SoapTestCore.java:745)
     [java] 	at com.zimbra.qa.soap.SoapTestCore.runTestFile(SoapTestCore.java:382)
     [java] 	at com.zimbra.qa.soap.SoapTestMain$StafTestDirectory.runTestDirectory(SoapTestMain.java:720)
     [java] 	at com.zimbra.qa.soap.SoapTestMain.execute(SoapTestMain.java:363)
     [java] 	at com.zimbra.qa.soap.SoapTestMain.main(SoapTestMain.java:492)
     [java] Caused by: java.net.SocketTimeoutException: connect timed out
     [java] 	at java.net.PlainSocketImpl.socketConnect(Native Method)
     [java] 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
     [java] 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
     [java] 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
     [java] 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
     [java] 	at java.net.Socket.connect(Socket.java:589)
     [java] 	at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:673)
     [java] 	at com.zimbra.common.net.CustomSSLSocket.connect(CustomSSLSocket.java:311)
     [java] 	at com.zimbra.common.net.CustomSSLSocket.connect(CustomSSLSocket.java:305)
     [java] 	at com.zimbra.common.net.CustomSSLSocketFactory.createSocket(CustomSSLSocketFactory.java:116)
     [java] 	at com.zimbra.common.net.CustomSSLSocketFactory.createSocket(CustomSSLSocketFactory.java:102)
     [java] 	at com.zimbra.common.net.ProtocolSocketFactoryWrapper.createSocket(ProtocolSocketFactoryWrapper.java:51)
     [java] 	at org.apache.commons.httpclient.HttpConnection.open(HttpConnection.java:707)
     [java] 	at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(HttpMethodDirector.java:387)
     [java] 	at org.apache.commons.httpclient.HttpMethodDirector.executeMethod(HttpMethodDirector.java:171)
     [java] 	at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:397)
     [java] 	at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:323)
     [java] 	at com.zimbra.qa.soap.ProxySoapHttpTransport.invoke(ProxySoapHttpTransport.java:283)
     [java] 	at com.zimbra.common.soap.SoapTransport.invoke(SoapTransport.java:447)
     [java] 	at com.zimbra.common.soap.SoapTransport.invokeRaw(SoapTransport.java:421)
     [java] 	at com.zimbra.qa.soap.SoapTest.doRequest(SoapTest.java:385)
     [java] 	at com.zimbra.qa.soap.SoapTest.executeSoapXML(SoapTest.java:151)
     [java] 	... 8 more
     [java] 16 Nov 2018 17:20:43,831 [soap.SoapTestMain$StafTestDirectory][main] :: ERROR   TEST FAILED: /opt/soap/zm-soap-harness/data/soapvalidator/SanityTest/AccountRequest_sanity.xml 
```