### PR TITLE
Zcs 7486

### DIFF
--- a/src/java/com/zimbra/qa/soap/SoapTestMain.java
+++ b/src/java/com/zimbra/qa/soap/SoapTestMain.java
@@ -213,7 +213,7 @@ public class SoapTestMain {
         		{
         			String type = iterator.next();
         			
-				if (type.equalsIgnoreCase("sanity") && !globalProperties.getProperty("ignoreFiles").toString().equalsIgnoreCase("true")) {
+        			if (type.equalsIgnoreCase("sanity") && !globalProperties.getProperty("ignoreFiles").toString().equalsIgnoreCase("true")) {
         				SoapTestMain.sHarnessTestCases = new File(SoapTestCore.rootZimbraQA + "/data/soapvalidator/SanityTest");
         			}
         		}


### PR DESCRIPTION
Avoiding hard coding of test path.
This was not allowing to skip tests mentioned in the ListOfTestCases file.
With this change sanity tests mentioned in the ListOfTestCases file will get skipped.