### PR TITLE
ZCS-7660: Add soap automation for Proxy Servlet Request and fix one more test case

### DIFF
--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug84501.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug84501.xml
@@ -161,7 +161,8 @@
 
 	<t:resttest>
 		<t:restServletRequest>
-			<basepath>/home/${account1.name}/calendar?fmt=freebusy</basepath>
+			<basepath>/home/${account1.name}/calendar</basepath>
+			<fmt>freebusy</fmt>
 			<s>${TIME(-1d)[${freebusy.start}]}</s>
 			<e>${TIME(+1d)[${freebusy.start}]}</e>
 		</t:restServletRequest>

--- a/data/soapvalidator/MailClient/Proxy/basic.xml
+++ b/data/soapvalidator/MailClient/Proxy/basic.xml
@@ -1,0 +1,88 @@
+<t:tests xmlns:t="urn:zimbraTestHarness">
+<t:property name="COS.name" value="testcos${TIME}${COUNTER}"/>
+<t:property name="account1.name" value="account${TIME}${COUNTER}@${defaultdomain.name}"/>
+
+<t:test_case testcaseid="Ping" type="always" >
+    <t:objective>basic system check</t:objective>
+    <t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
+    <t:test id="ping" required="true">
+        <t:request>
+            <PingRequest xmlns="urn:zimbraAdmin"/>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:PingResponse"/>
+        </t:response>
+    </t:test>
+</t:test_case>
+
+<t:test_case testcaseid="RestServlet_ProxyServlet_account_setup" type="always" bugids="ZCS-7660">
+    <t:objective>create test account</t:objective>
+
+    <t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
+    <t:test id="admin_login" required="true" >
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+                <name>${admin.user}</name>
+                <password>${admin.password}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+    <t:test id="createcosrequest" required="true">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${COS.name}</name>
+                <a n="zimbraProxyAllowedDomains">*.webex.com</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${COS.name}"/>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="COS.id"/>
+        </t:response>
+    </t:test>
+    <t:test required="true" >
+        <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                <name>${account1.name}</name>
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${COS.id}</a>
+            </CreateAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="id"  set="account1.id"/>
+            <t:select path='//admin:CreateAccountResponse/admin:account/admin:a[@n="zimbraMailHost"]' set="account1.server"/>
+        </t:response>
+    </t:test>
+</t:test_case>
+<t:test_case testcaseid="RestServlet_ProxyServlet_Request_01" type="smoke" bugids="ZCS-7660">
+    <t:objective>Verify ProxyServlet is working fine</t:objective>
+    <t:steps>
+     1. Login into account
+     2. Verify the proxy servlet request made to /service/proxy is executed with status code 200
+    </t:steps>
+    <t:property name="server.restServlet" value="${account1.server}"/>
+    <t:property name="server.zimbraAccount" value="${account1.server}"/>
+    <t:test id="auth1" required="true">
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+                <account by="name">${account1.name}</account>
+                <password>${defaultpassword.value}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+    <t:resttest>
+        <t:restServletRequest>
+            <basepath>/service/proxy</basepath>
+            <target>https://www.webex.com</target>
+        </t:restServletRequest>
+        <t:restServletResponse>
+            <t:select attr="StatusCode" match="200"/>
+        </t:restServletResponse>
+    </t:resttest>
+</t:test_case>
+</t:tests>

--- a/src/java/com/zimbra/qa/soap/RestServletTest.java
+++ b/src/java/com/zimbra/qa/soap/RestServletTest.java
@@ -87,7 +87,7 @@ public class RestServletTest extends Test {
 	public static final String A_REST_PREAUTH_EXPIRES = "expires";
 	public static final String A_REST_PREAUTH_ADMIN = "admin";
 	public static final String E_REST_PREAUTH_PREAUTH = "preauth";
-
+	public static final String A_REST_PROXY_TARGET = "target";
 
 	// POST attributes
 	public static final String A_REST_FILENAME = "filename";
@@ -1066,6 +1066,11 @@ public class RestServletTest extends Test {
 		String freebusyEnd = e.getAttribute(A_REST_FB_END, null);
 		if ( freebusyEnd != null ) {
 			queryMap.put("e", freebusyEnd);
+		}
+
+		String proxyTarget = e.getAttribute(A_REST_PROXY_TARGET, null);
+		if (proxyTarget != null) {
+			queryMap.put("target", proxyTarget);
 		}
 
 		Element preauth = e.getOptionalElement(E_REST_PREAUTH_PREAUTH);


### PR DESCRIPTION
Implemented new test for ProxyServlet requests made using /service/proxy with target query param.
Have to make changes in core framework for same.
New test case path - data/soapvalidator/MailClient/Proxy/basic.xml

Also, Fixed one RestServletTest making request to calendar?fmt=freebusy, which returned 404 but was still passing  i.e. data/soapvalidator/MailClient/Calendar/Bugs/bug84501.xml

Attached soap test results for reference -

[bug84501_404_error.txt](https://github.com/Zimbra/zm-soap-harness/files/3472805/bug84501_404_error.txt)
[bug84501_fixed.txt](https://github.com/Zimbra/zm-soap-harness/files/3472807/bug84501_fixed.txt)
[proxy_basic.txt](https://github.com/Zimbra/zm-soap-harness/files/3472808/proxy_basic.txt)


