### PR TITLE
ZCS-7680: Ability to have an option to block login using the alias

### DIFF
--- a/data/soapvalidator/MailClient/Auth/auth_alias.xml
+++ b/data/soapvalidator/MailClient/Auth/auth_alias.xml
@@ -186,21 +186,24 @@
 		<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
 	</t:response>
 	</t:test>
-	   <t:staftask>
-			<t:request>
-				<server>${zimbraServer.name}</server>
-				<service>PROCESS</service>
-				<params>START SHELL COMMAND "su - zimbra -c \'zmlocalconfig -e alias_login_enabled=true'" RETURNSTDOUT RETURNSTDERR WAIT
-					${staf.process.timeout.default}</params>
-			</t:request>
+</t:test_case>
+<t:finally type="always">
+	<t:objective>reset localconfig</t:objective>
+	<t:staftask>
+		<t:request>
+			<server>${zimbraServer.name}</server>
+			<service>PROCESS</service>
+			<params>START SHELL COMMAND "su - zimbra -c \'zmlocalconfig -e alias_login_enabled=true'" RETURNSTDOUT RETURNSTDERR WAIT
+				${staf.process.timeout.default}</params>
+		</t:request>
 	</t:staftask>
 	<t:staftask>
-			<t:request>
-				<server>${zimbraServer.name}</server>
-				<service>PROCESS</service>
-				<params>START SHELL COMMAND "su - zimbra -c \'zmmailboxdctl restart'" RETURNSTDOUT RETURNSTDERR WAIT
-					${staf.process.timeout.default}</params>
-			</t:request>
+		<t:request>
+			<server>${zimbraServer.name}</server>
+			<service>PROCESS</service>
+			<params>START SHELL COMMAND "su - zimbra -c \'zmmailboxdctl restart'" RETURNSTDOUT RETURNSTDERR WAIT
+				${staf.process.timeout.default}</params>
+		</t:request>
 	</t:staftask>
-</t:test_case>
+</t:finally>
 </t:tests>


### PR DESCRIPTION
Automation test case added to verify below points when "alias_login_enabled" local config value is set to false -
		1. Alias login will blocked
		2. Login with email address would work.
Soap test case result file attached -
[auth_alias.txt](https://github.com/Zimbra/zm-soap-harness/files/3499748/auth_alias.txt)
