### PR TITLE
ZCS-7765: Fix DAV related failures in zm-soap-harness legacy

### DIFF
--- a/src/java/com/zimbra/qa/soap/CalDavTest.java
+++ b/src/java/com/zimbra/qa/soap/CalDavTest.java
@@ -46,6 +46,9 @@ public class CalDavTest extends Test {
 	public static final String A_METHOD = "method";
 	public static final String A_URI = "uri";
 	public static final String A_DEPTH = "depth";
+
+	public static final String A_DEPTH_ZERO = "0";
+	public static final String A_DEPTH_ONE = "1";
 	public static final String A_ETAG = "etag";
 	public static final String E_ICAL = "ical";
 	public static final String A_HEADERS = "headers";
@@ -191,9 +194,9 @@ public class CalDavTest extends Test {
             mCalDavRequest = element.elementIterator().next();
             davRequest.setRequestMessage(mCalDavRequest.toXML().createCopy());
         }
-        if ( sDepth.equals("0") )
+        if (sDepth.equals(A_DEPTH_ZERO))
             davRequest.setDepth(Depth.zero);
-        else if ( sDepth.equals("1") )
+        else if (sDepth.equals(A_DEPTH_ONE) )
             davRequest.setDepth(Depth.one);
         else
             davRequest.setDepth(Depth.infinity);


### PR DESCRIPTION
Issue:
Getting NPE due to invoking of super() method for empty response (SC.NO_CONTENT) in DELETE, COPY and few other request methods in UserServlet.java at line no. 939. 

Fix:
Implement a custom method which does not invoke HttpInputStream.
  
/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Appointments/DeleteAppointment.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Folders/DeleteCalendar.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/copy.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/lock.xml
/opt/qa/soapvalidator/data/soapvalidator/Dav/WebDav/move.xml

Also fixes tests failing previously in -
/opt/qa/soapvalidator/data/soapvalidator/Dav/CalDav/Calendar/Mountpoints/DeleteAppointment.xml

Related Mailbox PR -
https://github.com/Zimbra/zm-mailbox/pull/954

Attached soap test results 
[7765_fixed.tar.gz](https://github.com/Zimbra/zm-soap-harness/files/3545878/7765_fixed.tar.gz)
