### PR TITLE
ZBUG-1109: spell check is not working correctly with 8.8.15

### DIFF
--- a/data/soapvalidator/MailClient/Misc/spell_check.xml
+++ b/data/soapvalidator/MailClient/Misc/spell_check.xml
@@ -23,7 +23,7 @@
 <t:property name="check.blank" value=""/>
 <t:property name="check.spaces" value="     "/>
 <t:property name="check.spchar" value=":/\\.;&lt;*''"/>
-
+<t:property name="check.utf8char" value="grüße"/>
 <t:property name="check.digit" value="1"/>
 <t:property name="check.decimal" value="12.34"/>
 <t:property name="check.negative" value="-1"/>
@@ -476,11 +476,15 @@
             RIM’s
             sehr geehrte damen und herren
             herzliche grüße
+	    读写汉字 - 学中文
+	    Wǒ xiān zǒu le
             </CheckSpellingRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:CheckSpellingResponse">
                  <t:select path="//mail:misspelled" emptyset="0"/>
+                 <t:select path="//mail:misspelled" attr="word"  match="${check.utf8char}"/>
+                 <t:select path='//mail:misspelled[@word="${check.utf8char}"]' attr="suggestions" match=".*grue,Gere,Gore,Grey,gore,grew,guru,gruel,grues.*"/>
             </t:select>
         </t:response>
     </t:test>


### PR DESCRIPTION
Updated existing automation for Spell check for additional special characters given in the mime attached in ticket.
attached smoke automation result for same -
[spell_check.txt](https://github.com/Zimbra/zm-soap-harness/files/3630031/spell_check.txt)

