### PR TITLE
ZCS-7856: Add utility to run SOAP automation tests through ec2 and send result email notification

### DIFF
--- a/utils/soap-run.sh
+++ b/utils/soap-run.sh
@@ -59,7 +59,7 @@ for argument in "$@"; do
 	value=$(echo ${argument} | cut -f2 -d=)
 	case "${key}" in
 		HOSTNAME) HOSTNAME=${value};;
-	    TESTROOT_DIR) TESTROOT_DIR=${value};;
+		TESTROOT_DIR) TESTROOT_DIR=${value};;
 		TESTS_SUITE) TESTS_SUITE=${value};;
 		BRANCH) BRANCH=${value};;
 		SOAP_HARNESS_BRANCH) SOAP_HARNESS_BRANCH=${value};;


### PR DESCRIPTION
The script intends to automate soap execution and will output soap results to Apache directory, so that the stake holders can get results in email and browse the results online.

The script needs an apache server and installed zimbra setup.

Below there are few cli options (in case not specified it will pick up the default options set in the script) - 

#HOSTNAME - zimbra server hostname
#TESTROOT_DIR - /opt/qa/soapvalidator/data/soapvalidator/
#TESTS_SUITE - SMOKE/FUNCTIONAL/SANITY/NEGATIVE
#BRANCH - develop / feature / bugfix
#SOAP_HARNESS_BRANCH - develop / feature / bugfix
... and so on.

Additionally, there are 2 options -
a) enable/disable compilation of mailbox,soap-harness repos and
b) enable/disable option to run staf commands & setup script which is a pre-requisite for executing soap automation.
below is an example usage -

./soap-run.sh HOSTNAME=zdev-vm016.eng.zimbra.com TESTROOT_DIR=/opt/qa/soapvalidator/data/soapvalidator TESTS_SUITE=SANITY 

Once soap run is completed, script will parse the nohup.out and send the results over email with failed/passed count &  the browsable link for e.g. 
http://zdev-vm016.eng.zimbra.com:81/soap-reports/20190929-081747/

Related Zimbra X PR - https://github.com/ZimbraOS/zm-docker-soap/pull/9