### PR TITLE
ZCS-7951: Fix for tgz Export/Import test cases

### DIFF
--- a/src/java/com/zimbra/qa/soap/RestServletTest.java
+++ b/src/java/com/zimbra/qa/soap/RestServletTest.java
@@ -360,7 +360,7 @@ public class RestServletTest extends Test {
 	}
 
 	private boolean isBinary(String contentType) {
-		if (contentType.equalsIgnoreCase("application/zip")) {
+		if (contentType.equalsIgnoreCase("application/zip") || contentType.equalsIgnoreCase("application/x-compressed-tar")) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
**Problem:**
All Export/Import related tests are failing due to improper `.tgz` format.

**Approach and Fix:**
This is originating because of the following commit `54060347ed73de7bb7570e0c28aa6c1851087fbb` in the `zm-mailbox` repo for the work that has been done in `ZCS-7700` Override `zimbra_ssl` and `zimbra_admin` upstreams. So, on removing the above commit for `ZCS-7700` the test was passing.

In the newer changes, the binary data is not getting saved to the file. In the test cases on changing the format from `tgz` to tar and all the tests of Export/Import seem to be passing. After the change of the regular and admin SOAP requests to pass-through, the new endpoint `tgz` format doesn't seem to be working but on changing it to `tar` it is working.

So, on seeing further into the `RestServletTest` class file noticed that in `processResponseHeaders` method only we are processing the headers if it has `Transfer-Encoding` or it's `Content-Type` is `text` or `application/zip` but not for the `application/x-compressed-tar`. This was the reason for changing the compression scheme from `Gzip` to `BZip2` Compression scheme in the `TgzFormatter` class the header was having `Transfer-Encoding` as `chunked` in the half of the test cases which were passing and rest were failing. So, to fix that also processing the header's `Content-Type` as `application/x-compressed-tar`.

All the scenarios are documented in the ticket [ZCS-7951](https://jira.corp.synacor.com/browse/ZCS-7951).

**Testing Done:**
- Ran all the `tgz` related Export/Import test cases, all of them are passing.
- Verified on the UI side that there is no functionality is breaking.