### PR TITLE
Add new Feature enable attributes for Zimbra 9

### DIFF
--- a/data/soapvalidator/MailClient/Misc/getinfo_request.xml
+++ b/data/soapvalidator/MailClient/Misc/getinfo_request.xml
@@ -25,7 +25,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="acct1_setup" type="always" >
+<t:test_case testcaseid="acct1_setup" type="always"  bugids="zcs-8474">
 	<t:objective>create test account</t:objective>
 
 	<t:test id="admin_login" required="true" >
@@ -45,13 +45,35 @@
 			<CreateAccountRequest xmlns="urn:zimbraAdmin">
 				<name>${test_account1.name}</name>
 				<password>${test_account1.password}</password>
+                <a n="zimbraFeatureMobileAppEnabled">TRUE</a>
 			</CreateAccountRequest>
 		</t:request>
 		<t:response>
 			<t:select path="//admin:CreateAccountResponse/admin:account" attr="id"  set="test_account1.id"/>
-                    <t:select path='//admin:CreateAccountResponse/admin:account/admin:a[@n="zimbraMailHost"]' set="test_acct.server"/>
+            <t:select path="//admin:CreateAccountResponse/admin:account//admin:a[@n='zimbraFeatureMobileAppEnabled']" match="TRUE"/>
+            <t:select path='//admin:CreateAccountResponse/admin:account/admin:a[@n="zimbraMailHost"]' set="test_acct.server"/>
 		</t:response>
 	</t:test>
+    <t:test >
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+                <account by="name">${test_account1.name}</account>
+                <password>${test_account1.password}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+    <t:test>
+        <t:request>
+            <GetInfoRequest xmlns="urn:zimbraAccount"/>
+        </t:request>
+        <t:response>
+            <t:select path="//acct:GetInfoResponse/acct:license//acct:attr[@name='ZIMBRAFEATUREMOBILEAPPENABLED']" match="TRUE"/>
+            <t:select path="//acct:GetInfoResponse/acct:license//acct:attr[@name='ZIMBRAFEATUREMODERNDESKTOPENABLED']" match="FALSE"/>
+        </t:response>
+    </t:test>
 
 </t:test_case>
 
@@ -78,7 +100,7 @@
 
 
 <t:test_case testcaseid="GetInfoRequest1" type="smoke" bugids="26254">
-	<t:objective> get info of account </t:objective>
+	<t:objective>Get info of account </t:objective>
 
 	<t:test>
 		<t:request>
@@ -252,6 +274,76 @@ Content Text
 	</t:test>
 
 
+</t:test_case>
+
+<t:property name="COS.name" value="cos${TIME}${COUNTER}"/>
+<t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+<t:property name="test_account2.password" value="test123"/>
+<t:test_case testcaseid="validateCOSattributes" bugids="zcs-8474" type="smoke">
+<t:objective>Validating cos attributes in getinfo</t:objective>
+    <t:test id="admin_login" required="true" >
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+                <name>${admin.user}</name>
+                <password>${admin.password}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+
+    <t:test>
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name>${COS.name}</name>
+                <a n="cn">${COS.name}</a>
+                <a n="zimbraFeatureModernDesktopEnabled">${globals.false}</a>
+                <a n="zimbraFeatureMobileAppEnabled">${globals.true}</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos//admin:a[@n='zimbraFeatureModernDesktopEnabled']" match="${globals.false}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos//admin:a[@n='zimbraFeatureMobileAppEnabled']" match="${globals.true}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="zimbraCosId" />
+        </t:response>
+    </t:test>
+    <t:test >
+        <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                <name>${test_account2.name}</name>
+                <password>${test_account2.password}</password>
+                <a n="zimbraFeatureModernDesktopEnabled">TRUE</a>
+                <a n="zimbraFeatureEwsEnabled">TRUE</a>
+                <a n="zimbraCOSId">${zimbraCosId}</a>
+            </CreateAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="id"  set="test_account1.id"/>
+            <t:select path="//admin:CreateAccountResponse/admin:account//admin:a[@n='zimbraFeatureMobileAppEnabled']" match="TRUE"/>
+            <t:select path="//admin:CreateAccountResponse/admin:account//admin:a[@n='zimbraFeatureModernDesktopEnabled']" match="TRUE"/>
+        </t:response>
+        </t:test>
+        <t:test >
+            <t:request>
+                <AuthRequest xmlns="urn:zimbraAccount">
+                    <account by="name">${test_account2.name}</account>
+                    <password>${test_account2.password}</password>
+                </AuthRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+            </t:response>
+        </t:test>
+        <t:test>
+            <t:request>
+                <GetInfoRequest xmlns="urn:zimbraAccount"/>
+            </t:request>
+            <t:response>
+                <t:select path="//acct:GetInfoResponse/acct:license//acct:attr[@name='ZIMBRAFEATUREMOBILEAPPENABLED']" match="TRUE"/>
+                <t:select path="//acct:GetInfoResponse/acct:license//acct:attr[@name='ZIMBRAFEATUREMODERNDESKTOPENABLED']" match="TRUE"/>
+            </t:response>
+        </t:test>
 </t:test_case>
 
 


### PR DESCRIPTION
Attributes:
zimbraFeatureMobileAppEnabled
zimbraFeatureModernDesktopEnabled
Automated scenarios:
1. Setting attributes on account level and verifying the same in createAccountResponse, GetInfoResponse.
2. Setting attributes on COS, creating an account on same COS but modifying one of the attribute on account level and validating the same in createAccountResponse, GetInfoResponse.

[getinfo_request.txt](https://github.com/Zimbra/zm-soap-harness/files/4158165/getinfo_request.txt)
