### PR TITLE
Add skip tests logic

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -494,9 +494,10 @@
 		<property name="testRoot" value="build/temp/data/soapvalidator/"/>
 		<property name="testSuite" value="smoke"/>
 		<property name="testResultDir" value="."/>
+		<property name="testRootOption" value="sf"/>
 		<echo>STAF: Executing ${testRoot} ${testSuite}</echo>
 		<java classname="com.zimbra.qa.soap.SoapTestMain" classpathref="test.class.path" fork="true" failonerror="true">
-			<arg line="-sf ${testRoot} -l conf/log4j-dev.properties -p conf/global.properties -z . -t ${testSuite} -j -o ${testResultDir}"/>
+			<arg line="-${testRootOption} ${testRoot} -l conf/log4j-dev.properties -p conf/global.properties -z . -t ${testSuite} -j -o ${testResultDir}"/>
 		</java>
 	</target>
 

--- a/src/java/com/zimbra/qa/soap/SoapTestMain.java
+++ b/src/java/com/zimbra/qa/soap/SoapTestMain.java
@@ -436,7 +436,7 @@ public class SoapTestMain {
 			BufferedReader bufferedReader = new BufferedReader(fr);
 			while ((line = bufferedReader.readLine()) != null) {
 				
-        			File enlistedTestCases = new File(SoapTestCore.rootZimbraQA + File.separatorChar + line);
+			        File enlistedTestCases = new File(line);
 				try {
 					execute(enlistedTestCases);
 				} catch (Exception e) {

--- a/src/java/com/zimbra/qa/soap/SoapTestMain.java
+++ b/src/java/com/zimbra/qa/soap/SoapTestMain.java
@@ -435,8 +435,8 @@ public class SoapTestMain {
 			FileReader fr = new FileReader(sHarnessTestSuite);
 			BufferedReader bufferedReader = new BufferedReader(fr);
 			while ((line = bufferedReader.readLine()) != null) {
-				
-			        File enlistedTestCases = new File(line);
+				// Get each test xml file from the list to execute.
+				File enlistedTestCases = new File(line);
 				try {
 					execute(enlistedTestCases);
 				} catch (Exception e) {


### PR DESCRIPTION
Fix path issue for skipping tests with -sf option

Adding new property in build.xml for testRootOption to be either 'f' or 'sf'. Default being 'sf'
i.e. 
```
Option f = new Option("f", "file", true, "input document or directory");
Option sf = new Option("sf", "runSelective", true, "execute tests scripts mentioned in a file");
```
It means we can support Zimbra 9 as well as Zimbra Cloud using this property option 

For zimbra 9
```
ant Run-SoapTestCore -DtestRootOption='f' -DtestSuite='smoke' -DtestRoot='build/temp/data/soapvalidator/' 
```

for Zimbra Cloud
```
ant Run-SoapTestCore -DtestRootOption='sf' -DtestSuite='smoke' -DtestRoot='build/temp/data/soapvalidator/' 
```

Currently, for Zimbra Cloud - list of test cases to be skipped is added here -
https://github.com/ZimbraOS/zm-docker-soap/blob/master/soap-bat/ListOfTestCases.txt

