### PR TITLE
replace hardcoded pwd value and read it from global properties

### DIFF
--- a/data/soapvalidator/MailClient/Calendar/Bugs/bug62368.xml
+++ b/data/soapvalidator/MailClient/Calendar/Bugs/bug62368.xml
@@ -5,7 +5,7 @@
 <t:property name="acct2.name" value="test2${TIME}.${COUNTER}@${defaultdomain.name}"/>
 
 
-<t:property name="acct.password" value="test123"/>
+<t:property name="acct.password" value="${defaultpassword.value}"/>
 
 <t:property name="appointment1.subject" value="Subj${TIME}.${COUNTER}"/>
 <t:property name="appointment2.subject" value="Subj2${TIME}.${COUNTER}"/>


### PR DESCRIPTION
Soap test: data/soapvalidator/MailClient/Calendar/Bugs/bug62368.xml is failing due to hard code password value: test123.
Admin has created account with default password and same account tried to authenticate with hard coded pwd as test123

Executed after change
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/MailClient/Calendar/Bugs/bug62368.xml
     [java]
     [java] REQUEST/RESPONSE Results: 12(PASS) - 0(Fail)
     [java]
     [java]
     [java] Tests Executed:12
     [java] Pass:12
     [java] Fail:0
