### PR TITLE
TestProperties class re-initialization for -sf option used in parellelism

### DIFF
--- a/src/java/com/zimbra/qa/soap/SoapTestMain.java
+++ b/src/java/com/zimbra/qa/soap/SoapTestMain.java
@@ -459,6 +459,8 @@ public class SoapTestMain {
     }
     
 	public static void execute(File testCases) throws HarnessException, InterruptedException, IOException {
+		// TestProperties class re-initialization
+		TestProperties.testProperties = new TestProperties();
 		if (testCases.isDirectory()) {
 			// run wsdl tests only when root folder of xml test specified.
 


### PR DESCRIPTION
Verified the fix by executing 2 test cases in auth.txt (one of which is Preauth)
```
root@soap-bat-1:/opt/soap/zm-soap-harness# cat conf/auth.txt
build/temp/data/soapvalidator/REST/Auth/Preauth/Admin/Preauth.xml
build/temp/data/soapvalidator/Search/Basic/Search-String-Comparison.xml

root@soap-bat-1:/opt/soap/zm-soap-harness# ant -DtestRoot="/opt/soap/zm-soap-harness/conf/auth.txt" -DtestRootOption="sf" Run-SoapTestCore

...
...
...
...

Run-SoapTestCore:
     [echo] STAF: Executing /opt/soap/zm-soap-harness/conf/ooo.txt smoke
     [java] 24 Apr 2020 09:36:47,514 [util.Log][main] :: WARN   local config file `/opt/zimbra/conf/localconfig.xml' is not readable
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/REST/Auth/Preauth/Admin/Preauth.xml
     [java] 24 Apr 2020 09:36:51,725 [httpclient.HttpMethodBase][main] :: WARN   Going to buffer response body of large or unknown size. Using getResponseBodyAsStream instead is recommended.
     [java]
     [java] REQUEST/RESPONSE Results: 7(PASS) - 0(Fail)
     [java]
     [java]
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/Search/Basic/Search-String-Comparison.xml
     [java]
     [java] REQUEST/RESPONSE Results: 7(PASS) - 0(Fail)
     [java]
     [java]
     [java] Tests Executed:14
     [java] Pass:14
     [java] Fail:0
     [java]
     [java] Test Cases Executed:2
     [java] Pass:2
     [java] Fail:0
     [java] Script Errors:0
     [java]
     [java] Tests Rerun Executed:0
     [java] Pass:0
     [java] Fail:0
     [java]
     [java] Test Cases Executed:0
     [java] Pass:0
     [java] Fail:0
     [java] Script Errors:0
     [java]
     [java]
     [java]
     [java] Test finished: PASS

BUILD SUCCESSFUL
Total time: 11 seconds
```