### PR TITLE
ZCS-9019: Modify lmtp inject function to use lmtp proxy instead of zimbraMailHost for Zimbra cloud soap tests

### DIFF
--- a/conf/global.properties
+++ b/conf/global.properties
@@ -3,6 +3,7 @@ server.zimbrax=false
 zimbraLDAPServer.name=localhost
 zimbraServer.name=localhost
 zimbraMailHost.name=localhost
+zimbraLMTPServer.name=localhost
 adminServer.name=localhost
 admin.mode=https
 admin.port=7071

--- a/conf/global.properties.zimbrax
+++ b/conf/global.properties.zimbrax
@@ -3,6 +3,7 @@ server.zimbrax=true
 zimbraLDAPServer.name=LDAP_SERVICE_NAME
 zimbraServer.name=ZIMBRA_HOST_NAME
 zimbraMailHost.name=ZIMBRA_MAILBOX_HOSTNAME
+zimbraLMTPServer.name=ZIMBRA_LMTP_HOSTNAME
 adminServer.name=ZIMBRA_HOST_NAME
 admin.mode=https
 admin.port=ADMIN_PORT

--- a/src/java/com/zimbra/qa/soap/MailInjectTest.java
+++ b/src/java/com/zimbra/qa/soap/MailInjectTest.java
@@ -393,7 +393,6 @@ public class MailInjectTest extends Test {
 
 		String lmtpTo = elem.getAttribute(A_LMTP_TO, null); // TODO: update to support multiple To: recipients
 		String lmtpFrom = elem.getAttribute(A_LMTP_FROM, null);
-		mLmtpServer = elem.getAttribute(A_LMTP_SERVER, null);
 
 		Element modifyElement = elem.getOptionalElement(A_LMTP_MODIFY);
 
@@ -553,7 +552,14 @@ public class MailInjectTest extends Test {
 		mLog.debug("elem: "+ elem);
 
 		String lmtpFileName = elem.getAttribute(A_LMTP_FILENAME, null);
-		String lmtpFolderName = elem.getAttribute(A_LMTP_FOLDERNAME, null);
+		String lmtpFolderName = elem.getAttribute(A_LMTP_FOLDERNAME, null);		
+		boolean mZimbraCloud = Boolean.parseBoolean(TestProperties.testProperties.getProperty("server.zimbrax", "false"));
+		
+		//If deployment is Zimbra Cloud, then get LMTP server value from global.properties. For Zimbra classic, get it from testcase
+		if( mZimbraCloud ) 
+			mLmtpServer = TestProperties.testProperties.getProperty("zimbraLMTPServer.name", "zmc-lmtp");
+		else
+			mLmtpServer = elem.getAttribute(A_LMTP_SERVER, null);
 
 
 		String resultMessage = "doLMTPInject: filename ("+lmtpFileName+
@@ -571,7 +577,7 @@ public class MailInjectTest extends Test {
 
 		mRequestDetails = mRequestDetails + "To: " + elem.getAttribute(A_LMTP_TO) + "\n";
 		mRequestDetails = mRequestDetails + "From: " + elem.getAttribute(A_LMTP_FROM) + "\n";
-		mRequestDetails = mRequestDetails + "Server: " + elem.getAttribute(A_LMTP_SERVER) + "\n";
+		mRequestDetails = mRequestDetails + "Server: " + mLmtpServer + "\n";
 
 		if ( lmtpFileName != null ) {
 


### PR DESCRIPTION
- Introduced global properties variable zimbraLMTPServer.name which would be LMTP server address (default lmtp proxy is zmc-lmtp)
- For Zimbra Cloud deployment, lmtp inject function gets LMTP server value as zimbraLMTPServer.name property 
- For Classic Zimbra, lmtp inject function gets LMTP server value as user's zimbraMailHost set by test  

See companion PR https://github.com/ZimbraOS/zm-docker-soap/pull/36 for changes in zm-docker-soap

**Testing Notes:**
Ran data/soapvalidator/Mail/LMTP/MimeBasic/Lmtp-Basic.xml testcase and verified that, lmtpinject is done on lmtp-proxy and test passed.

See below test run report:
[console.log](https://github.com/Zimbra/zm-soap-harness/files/4562631/console.log)

Below is the zmc-lmtp service log:
``{"level":"info","timestamp":"2020-05-01T04:15:35.329Z","logger":"lmtp.session","msg":"client connected","cid":"10.0.0.20:60928"}
{"level":"info","timestamp":"2020-05-01T04:15:35.591Z","logger":"lmtp.session","msg":"command finished","cid":"10.0.0.20:60928","cmd":"LHLO","args":"localhost","elapsed":"261.7795ms"}
{"level":"info","timestamp":"2020-05-01T04:15:35.914Z","logger":"lmtp.session","msg":"command finished","cid":"10.0.0.20:60928","cmd":"MAIL","args":"FROM:<foo@foo.com>","elapsed":"585.372656ms"}
{"level":"info","timestamp":"2020-05-01T04:15:36.188Z","logger":"lmtp.session","msg":"command finished","cid":"10.0.0.20:60928","cmd":"RCPT","args":"TO:<lmtp1588306527765.1@zmc.com>","elapsed":"859.746541ms"}
{"level":"info","timestamp":"2020-05-01T04:15:36.848Z","logger":"lmtp.session","msg":"command finished","cid":"10.0.0.20:60928","cmd":"DATA","args":"","elapsed":"1.518817467s"}
{"level":"info","timestamp":"2020-05-01T04:15:36.862Z","logger":"lmtp.session","msg":"client connected","cid":"172.17.0.1:37250"}
{"level":"info","timestamp":"2020-05-01T04:15:36.862Z","logger":"lmtp.session","msg":"session complete","cid":"172.17.0.1:37250","total":"162.02µs"}
{"level":"info","timestamp":"2020-05-01T04:15:37.110Z","logger":"lmtp.session","msg":"command finished","cid":"10.0.0.20:60928","cmd":"QUIT","args":"","elapsed":"1.780980387s"}
{"level":"info","timestamp":"2020-05-01T04:15:37.110Z","logger":"lmtp.session","msg":"session complete","cid":"10.0.0.20:60928","total":"1.781251278s"}``