### PR TITLE
Update build.xml file to execute 2 different test suite together, i.e. "smoke, bhr", "smoke, functional", "bhr, functional" and so on

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -492,22 +492,26 @@
 
 	<target name="Run-SoapTestCore" depends="compile,zm-network-soap-content" description="Run Staf Tests in non-STAF environment">
 		<property name="testRoot" value="build/temp/data/soapvalidator/"/>
-		<property name="testSuite1" value="smoke"/>
-		<property name="testSuite2" value="" />
+		<property name="testSuite" value="smoke"/>
 		<property name="testResultDir" value="."/>
 		<property name="testRootOption" value="f"/>
-		<if>
-			<equals arg1="${testSuite2}" arg2="" />
-			<then>
-				<property name="testSuite" value="${testSuite1}" />
-			</then>
-			<else>
-				<property name="testSuite" value="${testSuite1} -t ${testSuite2}" />
-			</else>
-		</if>
-		<echo>STAF: Executing ${testRoot} ${testSuite}</echo>
+		<script language="javascript">
+			<![CDATA[
+				validTestSuites = ["smoke", "sanity", "bhr", "functional"];
+				testSuiteArr = project.getProperty('testSuite').split(',');
+				testSuiteStr = "";
+				for(i=0; i < testSuiteArr.length; i++) {
+					// Check if the testSuite is valid one.
+					if (validTestSuites.indexOf(testSuiteArr[i]) >-1) {
+						testSuiteStr = testSuiteStr + " -t " + testSuiteArr[i];
+					}
+				}
+				project.setProperty("testSuiteList", testSuiteStr);
+			]]>
+		</script>
+		<echo>STAF: Executing ${testRoot} ${testSuiteList} </echo>
 		<java classname="com.zimbra.qa.soap.SoapTestMain" classpathref="test.class.path" fork="true" failonerror="true">
-			<arg line="-${testRootOption} ${testRoot} -l conf/log4j-dev.properties -p conf/global.properties -z . -t ${testSuite} -j -o ${testResultDir}"/>
+			<arg line="-${testRootOption} ${testRoot} -l conf/log4j-dev.properties -p conf/global.properties -z . ${testSuiteList} -j -o ${testResultDir}"/>
 		</java>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -492,9 +492,19 @@
 
 	<target name="Run-SoapTestCore" depends="compile,zm-network-soap-content" description="Run Staf Tests in non-STAF environment">
 		<property name="testRoot" value="build/temp/data/soapvalidator/"/>
-		<property name="testSuite" value="smoke"/>
+		<property name="testSuite1" value="smoke"/>
+		<property name="testSuite2" value="" />
 		<property name="testResultDir" value="."/>
 		<property name="testRootOption" value="f"/>
+		<if>
+			<equals arg1="${testSuite2}" arg2="" />
+			<then>
+				<property name="testSuite" value="${testSuite1}" />
+			</then>
+			<else>
+				<property name="testSuite" value="${testSuite1} -t ${testSuite2}" />
+			</else>
+		</if>
 		<echo>STAF: Executing ${testRoot} ${testSuite}</echo>
 		<java classname="com.zimbra.qa.soap.SoapTestMain" classpathref="test.class.path" fork="true" failonerror="true">
 			<arg line="-${testRootOption} ${testRoot} -l conf/log4j-dev.properties -p conf/global.properties -z . -t ${testSuite} -j -o ${testResultDir}"/>


### PR DESCRIPTION
Update Existing ant target to support multiple Test Suites.
There is already a facility for this in java code i.e. 
if we pass multiple Test Suites using below Args
 
`-t smoke -t bhr`

Few examples to execute as below -
```

ant Run-SoapTestCore -DtestSuite1="smoke" -DtestSuite2="bhr"

ant Run-SoapTestCore -DtestSuite1="smoke" -DtestSuite2="functional"

ant Run-SoapTestCore -DtestSuite1="smoke" -DtestSuite2="negative"
```

**Note:** 
This may impact changes in execute test scripts to pass _testSuite1_ instead of _testSuite_ now and needs to be handled separately.

Please kindly check all comments before reviewing as this was being discussed and logic is now updated accordingly.

Related PR:
https://github.com/ZimbraOS/zm-continuous-integration/pull/62

