### PR TITLE
ZCS-9569: Added tests for ChangePassword with dryRun option

### DIFF
--- a/data/soapvalidator/General/Password/Change-Password-DryRun.xml
+++ b/data/soapvalidator/General/Password/Change-Password-DryRun.xml
@@ -1,0 +1,384 @@
+<t:tests xmlns:t="urn:zimbraTestHarness">
+
+<t:property name="cos1.name" value="COS.${TIME}.${COUNTER}"/>
+
+<t:property name="account1.name" value="account.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+<t:property name="account2.name" value="account.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+
+<t:property name="validpassword.value1" value="Test12$"/>
+<t:property name="validpassword.value2" value="34Abc#"/>
+<t:property name="validpassword.value3" value="!Pnq45"/>
+
+<t:property name="invalidpasswordlength.value1" value="Te12$"/>
+<t:property name="invalidpasswordnumpunc.value2" value="Test1#"/>
+<t:property name="invalidpassworduppercase.value3" value="test12$"/>
+<t:property name="invalidpasswordlowercase.value4" value="TEST12$"/>
+
+<t:property name="dryrun.value1" value="1"/>
+<t:property name="dryrun.value2" value="true"/>
+
+<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/> 
+
+<t:test_case testcaseid="CreateAccountPasswordRuleOnCos" type="always" >
+	<t:objective>Password Rule on Create account applied by COS</t:objective>
+	
+	<t:test required="true">
+		<t:request>
+			<AuthRequest xmlns="urn:zimbraAdmin">
+				<name>${admin.user}</name>
+				<password>${admin.password}</password>
+			</AuthRequest>
+		</t:request>
+		<t:response>
+			<t:select path="//admin:AuthResponse/admin:authToken" set="authToken"/>
+		</t:response>
+	</t:test>
+	
+  	<t:test required="true">
+ 		<t:request>
+  			<CreateCosRequest xmlns="urn:zimbraAdmin">
+    			<name>${cos1.name}</name>
+    			<a n="zimbraPasswordMinLength">6</a>
+   	 			<a n="zimbraPasswordMinDigitsOrPuncs">3</a>
+   	 			<a n="zimbraPasswordAllowedPunctuationChars">[#!@%$]</a>
+   	 			<a n="zimbraPasswordMinUpperCaseChars">1</a>
+   	 			<a n="zimbraPasswordMinLowerCaseChars">2</a>
+   	 			<a n="zimbraPasswordEnforceHistory">5</a>
+   			</CreateCosRequest>
+ 		</t:request>
+ 		<t:response>
+			<t:select path="//admin:CreateCosResponse/admin:cos" attr="id"  set="cos1.id"/>
+ 		</t:response>
+	</t:test>
+	
+	  <t:test>
+        <t:request>
+	        <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                <name>${account1.name}</name>
+                <password>${validpassword.value1}</password>
+                <a n="zimbraCOSId">${cos1.id}</a>
+            </CreateAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account"/>
+        </t:response>
+      </t:test>   
+	     
+</t:test_case>
+
+
+<t:test_case testcaseid="ChangePassword-LengthRule" type="bhr">
+	<t:objective>Verify ChangePassword with dryrun returns correct error when zimbraPasswordMinLength rule condition fails and password is not changed</t:objective>
+		<t:test required="true">
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value1}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+	
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value1}</oldPassword>
+	    			<password>${invalidpasswordlength.value1}</password>
+	    			<dryRun>${dryrun.value1}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	    		<t:select path="//zimbra:Code" match="account.INVALID_PASSWORD"/>
+	    		<t:select path="//soap:Text" match="invalid password: too short"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${invalidpasswordlength.value1}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+		
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value1}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" emptyset="0"/>
+			</t:response>
+		</t:test>
+            
+</t:test_case>
+
+<t:test_case testcaseid="ChangePassword-HistoryRule" type="bhr">
+	<t:objective>Verify ChangePassword with dryrun returns correct error when zimbraPasswordEnforceHistory rule condition fails and password is not changed</t:objective>
+		<t:test required="true">
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value1}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value1}</oldPassword>
+	    			<password>${validpassword.value2}</password>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+		</t:test>
+		
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${validpassword.value1}</password>
+	    			<dryRun>${dryrun.value2}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	    		<t:select path="//zimbra:Code" match="account.PASSWORD_RECENTLY_USED"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value1}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+		
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" emptyset="0"/>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+            
+</t:test_case>
+
+<t:test_case testcaseid="ChangePassword-OtherRules" type="bhr">
+	<t:objective>Verify ChangePassword with dryrun returns correct error when zimbraPasswordMinDigitsOrPuncs, zimbraPasswordMinUpperCaseChars, zimbraPasswordMinLowerCaseChars rule condition fails and password is not changed</t:objective>
+		<t:test required="true">
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${invalidpasswordnumpunc.value2}</password>
+	    			<dryRun>${dryrun.value1}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	    		<t:select path="//zimbra:Code" match="account.INVALID_PASSWORD"/>
+	    		<t:select path="//soap:Text" match="invalid password: not enough numeric or punctuation characters"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${invalidpasswordnumpunc.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${invalidpassworduppercase.value3}</password>
+	    			<dryRun>${dryrun.value1}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	    		<t:select path="//zimbra:Code" match="account.INVALID_PASSWORD"/>
+	    		<t:select path="//soap:Text" match="invalid password: not enough upper case characters"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${invalidpassworduppercase.value3}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${invalidpasswordlowercase.value4}</password>
+	    			<dryRun>${dryrun.value1}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	    		<t:select path="//zimbra:Code" match="account.INVALID_PASSWORD"/>
+	    		<t:select path="//soap:Text" match="invalid password: not enough lower case characters"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${invalidpasswordlowercase.value4}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+            
+</t:test_case>
+
+<t:test_case testcaseid="ChangePassword-Valid" type="bhr">
+	<t:objective>Verify ChangePassword with dryrun with valid password does not change password, password is changed without dryrun</t:objective>
+		<t:test required="true">
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${validpassword.value3}</password>
+	    			<dryRun>${dryrun.value1}</dryRun>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	 			<t:select path="//zimbra:Code" emptyset="1"/>
+	    		<t:select path="//acct:ChangePasswordResponse/acct:authToken" emptyset="1"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value3}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" match="account.AUTH_FAILED"/>
+			</t:response>
+		</t:test>
+		
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value2}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//acct:AuthResponse/acct:authToken" emptyset="0"/>
+				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+			</t:response>
+		</t:test>
+		
+		<t:test>
+	 		<t:request>
+	  			<ChangePasswordRequest xmlns="urn:zimbraAccount">
+	    			<account>${account1.name}</account>
+	    			<oldPassword>${validpassword.value2}</oldPassword>
+	    			<password>${validpassword.value3}</password>
+	  			</ChangePasswordRequest>
+	 		</t:request>
+	 		<t:response>
+	 			<t:select path="//zimbra:Code" emptyset="1"/>
+	    		<t:select path="//acct:ChangePasswordResponse/acct:authToken" emptyset="0"/>
+	 		</t:response>
+		</t:test>
+	
+		<t:test required="true" >
+			<t:request>
+				<AuthRequest xmlns="urn:zimbraAccount">
+					<account>${account1.name}</account>
+					<password>${validpassword.value3}</password>
+				</AuthRequest>
+			</t:request>
+			<t:response>
+				<t:select path="//zimbra:Code" emptyset="1"/>
+				<t:select path="//acct:AuthResponse/acct:authToken" emptyset="0"/>
+			</t:response>
+		</t:test>
+            
+</t:test_case>
+
+
+</t:tests>


### PR DESCRIPTION
Added ChangePassword tests for:
1. dryRun=1 with password not satisfying length rule - zimbraPasswordMinLength
2. dryRun=true with password not satisfying history rule - zimbraPasswordEnforceHistory
3. dryRun=1 with password rules - zimbraPasswordMinDigitsOrPuncs, zimbraPasswordMinUpperCaseChars, zimbraPasswordMinLowerCaseChars
4. dryRun=1 with valid password - should not change password, authToken not returned  in response
5. Without dryRun and valid password - should change password, authToken is returned  in response