### PR TITLE
ZCS-10056: Fixed Filter SOAP testcase script issues

### DIFF
--- a/data/soapvalidator/Prefs/Filters/Bugs/Bug37018.xml
+++ b/data/soapvalidator/Prefs/Filters/Bugs/Bug37018.xml
@@ -218,6 +218,8 @@
         </t:response>
     </t:test>
 
+    <t:delay sec="10" />
+
 	<!-- Login to account4 -->
 	<t:test required="true">
         <t:request>

--- a/data/soapvalidator/Prefs/Filters/Bugs/Bug77367.xml
+++ b/data/soapvalidator/Prefs/Filters/Bugs/Bug77367.xml
@@ -65,7 +65,6 @@
 
 </t:test_case>
 
-
 <t:test_case testcaseid="bug77367_1" type="bhr" bugids="77367">
     <t:objective>Notifyaction filter can result in mail loop</t:objective>
     <t:steps>
@@ -92,8 +91,8 @@
     
     <t:property name="filter1.name" value="filter${TIME}${COUNTER}"/>
 	<t:property name="filter1.subject" value="filter${TIME}${COUNTER}"/>	
-	<t:property name="notify.subject" value="Thanks $\{from} $\{SUBJECT}"/>
-	<t:property name="notify.body" value="Dear $\{from} with subject $\{SUBJECT} and body $\{BODY}"/>
+	<t:property name="notify1.subject" value="Notify subject account1"/>
+	<t:property name="notify1.body" value="Notify body account1"/>
 	<t:test>
 		<t:request>
 			<ModifyFilterRulesRequest xmlns="urn:zimbraMail">
@@ -103,8 +102,8 @@
 							<headerTest header="Subject" stringComparison="contains" value="${filter1.subject}" />
 						</filterTests>
 						<filterActions>
-							  <actionNotify a="${account2.name}" su="${notify.subject}">
-           						 <content>${notify.body}</content>
+							  <actionNotify a="${account2.name}" su="${notify1.subject}">
+           						 <content>${notify1.body}</content>
            					 </actionNotify>
            					 <actionKeep />
   						<actionStop />
@@ -133,8 +132,8 @@
      
     <t:property name="filter2.name" value="filter${TIME}${COUNTER}"/>
 	<t:property name="filter2.subject" value="filter${TIME}${COUNTER}"/>	
-	<t:property name="notify.subject" value="Thanks $\{from} $\{SUBJECT}"/>
-	<t:property name="notify.body" value="Dear $\{from} with subject $\{SUBJECT} and body $\{BODY}"/>
+	<t:property name="notify2.subject" value="Notify subject account2"/>
+	<t:property name="notify2.body" value="Notify body account2"/>
 	
 	<t:test>
 		<t:request>
@@ -145,8 +144,8 @@
 							<headerTest header="Subject" stringComparison="contains" value="${filter1.subject}" />
 						</filterTests>
 						<filterActions>
-							  <actionNotify a="${account1.name}" su="${notify.subject}">
-           						 <content>${notify.body}</content>
+							  <actionNotify a="${account1.name}" su="${notify2.subject}">
+           						 <content>${notify2.body}</content>
            					 </actionNotify>
            					 <actionKeep />
   						<actionStop />
@@ -197,7 +196,7 @@
      <t:test>
 		<t:request>
 			<SearchRequest xmlns="urn:zimbraMail" types="message">
-				<query>${notify.body}</query>
+				<query>${notify2.body}</query>
 			</SearchRequest>
 		</t:request>
 		<t:response>
@@ -271,8 +270,8 @@
     
     <t:property name="filter1.name" value="filter${TIME}${COUNTER}"/>
 	<t:property name="filter1.subject" value="testfilter${TIME}${COUNTER}"/>	
-	<t:property name="notify.subject" value="Thanks $\{from} $\{SUBJECT}"/>
-	<t:property name="notify.body" value="Dear $\{from} with subject $\{SUBJECT} and body $\{BODY}"/>
+	<t:property name="reply1.subject" value="Reply subject account1"/>
+	<t:property name="reply1.body" value="Reply body account1"/>
 	<t:test>
 		<t:request>
 			<ModifyFilterRulesRequest xmlns="urn:zimbraMail">
@@ -282,8 +281,8 @@
 							<headerTest header="Subject" stringComparison="contains" value="${filter1.subject}" />
 						</filterTests>
 						<filterActions>
-							  <actionReply a="${account2.name}" su="${notify.subject}">
-           						 <content>${notify.body}</content>
+							  <actionReply a="${account2.name}" su="${reply1.subject}">
+           						 <content>${reply1.body}</content>
            					 </actionReply>
            					 <actionKeep />
   						<actionStop />
@@ -312,8 +311,8 @@
      
     <t:property name="filter2.name" value="filter${TIME}${COUNTER}"/>
 	<t:property name="filter2.subject" value="filter${TIME}${COUNTER}"/>	
-	<t:property name="notify.subject" value="Thanks $\{from} $\{SUBJECT}"/>
-	<t:property name="notify.body" value="Dear $\{from} with subject $\{SUBJECT} and body $\{BODY}"/>
+	<t:property name="reply2.subject" value="Reply subject account2"/>
+	<t:property name="reply2.body" value="Reply body account2"/>
 	
 	<t:test>
 		<t:request>
@@ -324,8 +323,8 @@
 							<headerTest header="Subject" stringComparison="contains" value="${filter1.subject}" />
 						</filterTests>
 						<filterActions>
-							  <actionReply a="${account1.name}" su="${notify.subject}">
-           						 <content>${notify.body}</content>
+							  <actionReply a="${account1.name}" su="${reply2.subject}">
+           						 <content>${reply2.body}</content>
            					 </actionReply>
            					 <actionKeep />
   						<actionStop />

--- a/data/soapvalidator/Prefs/Filters/Conditions/Filter-AddressIn.xml
+++ b/data/soapvalidator/Prefs/Filters/Conditions/Filter-AddressIn.xml
@@ -156,6 +156,7 @@
         </t:response>
     </t:test>
 
+    <t:delay sec="10" />
 	
     <t:mailinjecttest >
         <t:lmtpInjectRequest>
@@ -239,6 +240,8 @@
         </t:response>
     </t:test>
     
+    <t:delay sec="10" />
+ 
     <t:mailinjecttest >
         <t:lmtpInjectRequest>
             <filename>${msg01.file}</filename>
@@ -339,6 +342,8 @@
         </t:response>
     </t:test>
     
+    <t:delay sec="10" />
+    
     <t:mailinjecttest >
         <t:lmtpInjectRequest>
             <filename>${msg01.file}</filename>
@@ -421,6 +426,8 @@
         </t:response>
     </t:test>
    
+    <t:delay sec="10" />
+
     <t:mailinjecttest >
         <t:lmtpInjectRequest>
             <filename>${msg01.file}</filename>
@@ -502,6 +509,8 @@
             <t:select path="//mail:GetFilterRulesResponse"/>
         </t:response>
     </t:test>
+
+    <t:delay sec="10" />
    
     <t:mailinjecttest >
         <t:lmtpInjectRequest>

--- a/data/soapvalidator/Prefs/Filters/Outgoing/ApplyOutgoingfilterRules-Basic.xml
+++ b/data/soapvalidator/Prefs/Filters/Outgoing/ApplyOutgoingfilterRules-Basic.xml
@@ -88,6 +88,8 @@
             <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="message1.id"/>
         </t:response>
     </t:test>
+
+ <t:delay sec="10" />
   
  <t:test>
         <t:request>
@@ -378,6 +380,7 @@
         </t:response>
     </t:test>
   
+ <t:delay sec="10" />
 
    <t:test>
         <t:request>
@@ -435,9 +438,6 @@
     </t:test>	
 
 </t:test_case>
-
-
-
 
 </t:tests>
 

--- a/data/soapvalidator/Prefs/Filters/Priority/AddressBookTest.xml
+++ b/data/soapvalidator/Prefs/Filters/Priority/AddressBookTest.xml
@@ -156,6 +156,8 @@
    
 	<t:property name="addressBook_msg01.file" value="${testMailRaw.root}/bug42185/addressbook01.txt" />
 
+    <t:delay sec="10" />
+
 	<t:mailinjecttest >
         <t:lmtpInjectRequest>
             <filename>${addressBook_msg01.file}</filename>
@@ -234,6 +236,8 @@
     </t:test>
     
     <t:property name="addressBook_msg02.file" value="${testMailRaw.root}/bug42185/addressbook02.txt" />
+    
+    <t:delay sec="10" />
     
     <t:mailinjecttest >
         <t:lmtpInjectRequest>


### PR DESCRIPTION
- Fixed Bug77367.xml script which was failing due to incorrect search keywords used
- Other failures were due to timing issue where message got injected/sent immediately after filter was created. Added 10 seconds delay and verified that test are passing.