### PR TITLE
ZCS-10082: Fixed Sieve testcases - part1

### DIFF
--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug104314.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug104314.xml
@@ -26,6 +26,7 @@
 <t:property name="server.spaceinname" value="testserver    ${TIME}${COUNTER}"/>
 <t:property name="server.notes" value="test of adding Server via SOAP"/>
 <t:property name="server.desc" value="test server description"/>
+<t:property name="cos.name" value="cos104314${TIME}${COUNTER}" />
 
 <t:property name="sieve_rule1" value='require ["editheader", "log"];
 replaceheader :newvalue "[Spam] ${mail_subject}" :matches "subject" "*";
@@ -113,7 +114,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-		<t:test>
+		<!--<t:test>
 			<t:request>
 				<ModifyConfigRequest xmlns="urn:zimbraAdmin">
 					<a n="zimbraCustomMimeHeaderNameAllowed">X-Spam-Score</a>
@@ -148,8 +149,22 @@ log "done";'/>
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-	    
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cos.id" />
+            </t:response>
+        </t:test>
+
 </t:test_case>
 
 <t:test_case testcaseid="Accounts setup" type="bhr">  
@@ -159,6 +174,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -172,6 +188,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -185,6 +202,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -198,6 +216,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -211,6 +230,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -224,6 +244,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -237,6 +258,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -249,7 +271,8 @@ log "done";'/>
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account8.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>              
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -263,6 +286,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account9.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -276,6 +300,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account10.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -289,6 +314,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account11.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -302,6 +328,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account12.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -315,6 +342,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account13.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -328,6 +356,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account14.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -341,6 +370,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${dl1.member1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -354,6 +384,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${dl1.member2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -640,7 +671,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-    <t:test>
+    <!--<t:test>
         <t:request>
             <ModifyConfigRequest xmlns="urn:zimbraAdmin">
                 <a n="zimbraCustomMimeHeaderNameAllowed">X-Sieve-Header</a>
@@ -649,7 +680,7 @@ log "done";'/>
         <t:response>
             <t:select path="//admin:ModifyConfigResponse"/>
         </t:response>
-    </t:test>
+    </t:test>-->
     	
     <t:test id = "modifyaccountrequest01">
         <t:request>
@@ -733,7 +764,7 @@ log "done";'/>
     <steps> 
         1. Add sieve rule for the user :index 1 :newvalue "[NEWVAL] $\{1}" :matches "X-Header" "*";
 		2. Verify if there are multiple X-Headers in mime, the 1st one should be matched and replaced with newvalue -- X-Header: [NEWVAL] My header
-    </steps>	
+    </steps>
 
 	<t:test required="true">
 		<t:request>
@@ -841,7 +872,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-    <t:test>
+    <!--<t:test>
         <t:request>
             <ModifyConfigRequest xmlns="urn:zimbraAdmin">
                 <a n="zimbraCustomMimeHeaderNameAllowed">X-Sieve-Header</a>
@@ -850,7 +881,7 @@ log "done";'/>
         <t:response>
             <t:select path="//admin:ModifyConfigResponse"/>
         </t:response>
-    </t:test>
+    </t:test>-->
     	
     <t:test id = "modifyaccountrequest01">
         <t:request>
@@ -948,7 +979,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-    <t:test>
+    <!--<t:test>
         <t:request>
             <ModifyConfigRequest xmlns="urn:zimbraAdmin">
                 <a n="zimbraCustomMimeHeaderNameAllowed">X-Sieve-Header</a>
@@ -957,7 +988,7 @@ log "done";'/>
         <t:response>
             <t:select path="//admin:ModifyConfigResponse"/>
         </t:response>
-    </t:test>
+    </t:test>-->
     	
     <t:test id = "modifyaccountrequest01">
         <t:request>
@@ -1055,7 +1086,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-    <t:test>
+    <!--<t:test>
         <t:request>
             <ModifyConfigRequest xmlns="urn:zimbraAdmin">
                 <a n="zimbraCustomMimeHeaderNameAllowed">X-Sieve-Header</a>
@@ -1064,7 +1095,7 @@ log "done";'/>
         <t:response>
             <t:select path="//admin:ModifyConfigResponse"/>
         </t:response>
-    </t:test>
+    </t:test>-->
     	
     <t:test id = "modifyaccountrequest01">
         <t:request>
@@ -1689,7 +1720,7 @@ log "done";'/>
     </t:test>
      
 </t:test_case>
-
+<!--
     <t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
@@ -1729,5 +1760,5 @@ log "done";'/>
 	        </t:response>
 	    </t:test>
 
-    </t:finally>   
+    </t:finally>   -->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug104912.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug104912.xml
@@ -354,7 +354,7 @@ if address :is :all "from" "admin@${defaultdomain.name}"
 			</t:response>
 		</t:test>
 
-		<t:test>
+		<!--<t:test>
 			<t:request>
 				<ModifyConfigRequest xmlns="urn:zimbraAdmin">
 					<a n="zimbraCustomMimeHeaderNameAllowed">X-Spam-Score</a>
@@ -364,7 +364,7 @@ if address :is :all "from" "admin@${defaultdomain.name}"
 			<t:response>
 				<t:select path="//admin:ModifyConfigResponse" />
 			</t:response>
-		</t:test>
+		</t:test>-->
 
 		<t:test>
 			<t:request>
@@ -1749,6 +1749,8 @@ if address :is :all "from" "admin@${defaultdomain.name}"
 					set="Sent_message1.id" />
 			</t:response>
 		</t:test>
+
+               <t:delay sec="5" />
 
 		<t:test>
 			<t:request>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug105636.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug105636.xml
@@ -18,6 +18,7 @@
 <t:property name="reject_mail_subject" value="Disposition notification" />
 <t:property name="reject_mail_content" value="Message matched the reject conditions (policy)" />
 <t:property name="ereject_mail_subject" value="Undelivered Mail Returned to Sender" />
+<t:property name="cos.name" value="cos105636${TIME}${COUNTER}" />
 
 <t:property name="server.name" value="testserver${TIME}${COUNTER}"/>
 <t:property name="server.spaceinname" value="testserver    ${TIME}${COUNTER}"/>
@@ -90,7 +91,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -112,13 +113,27 @@ if envelope :domain :is "to" "${defaultdomain.name}"
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveRejectMailEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cos.id" />
+        </t:response>
+    </t:test>
 	                    
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -132,6 +147,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -145,6 +161,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -158,6 +175,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -171,6 +189,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -184,6 +203,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -197,6 +217,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -211,6 +232,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
                 <name>${test_account8.name}</name>
                 <password>${defaultpassword.value}</password>
                 <a n = "zimbraPrefLocale">ja</a>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -224,6 +246,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account9.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -237,6 +260,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account10.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -249,6 +273,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${dl1.member1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -262,6 +287,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${dl1.member2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -896,7 +922,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
 	        
 </t:test_case>
 
-<t:test_case testcaseid="bug105626_disable_sieve" type="bhr" bugids="105626">
+<t:test_case testcaseid="bug105626_disable_sieve" type="functional" bugids="105626">
    <t:objective>Mail filter misses the 'reject' action</t:objective>
     <steps> 
         1. Add sieve rule for the user
@@ -931,7 +957,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
 	    <t:test >
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
+	                <id>${cos.id}</id>
 	                <a n="zimbraSieveRejectMailEnabled">FALSE</a>
 	            </ModifyCosRequest>
 	        </t:request>
@@ -1005,7 +1031,7 @@ if envelope :domain :is "to" "${defaultdomain.name}"
     </t:test>		        
 </t:test_case> 
 
-<t:finally>
+<!--<t:finally>
 
 	<t:test required="true">
 		<t:request>
@@ -1031,6 +1057,6 @@ if envelope :domain :is "to" "${defaultdomain.name}"
 	        </t:response>
 	    </t:test>
 
-</t:finally>
+</t:finally>-->
 
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106838.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106838.xml
@@ -9,6 +9,7 @@
 	<t:property name="variable_body_text" value="$\{body_text}"></t:property>
 	<t:property name="mail_subject_1" value="mail_subject"></t:property>
 	<t:property name="mail_content" value="Hi,\\rYou have got a mail!\\r."></t:property>
+        <t:property name="cos.name" value="cos106838${TIME}${COUNTER}" />
 
 	<t:property name="sieve_rule1"
 		value='
@@ -48,7 +49,7 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -70,13 +71,28 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+            <t:test id="CreateCosRequest1">
+                <t:request>
+                    <CreateCosRequest xmlns="urn:zimbraAdmin">
+                        <name xmlns="">${cos.name}</name>
+                        <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                    </CreateCosRequest>
+                </t:request>
+                <t:response>
+                   <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                   <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cos.id" />
+                </t:response>
+            </t:test>
+
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cos.id}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -93,6 +109,7 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cos.id}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -108,6 +125,7 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cos.id}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -190,7 +208,7 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 
 	</t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -217,5 +235,5 @@ notify :message "Notification mail." "mailto:${test_account3.name}?Importance=Hi
 	        </t:response>
 	    </t:test>
 
-    </t:finally>		
+    </t:finally>-->		
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106845.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106845.xml
@@ -10,6 +10,7 @@
     <t:property name="test_notify_account4.name" value="notify4.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account5.name" value="test5.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_notify_account5.name" value="notify5.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos106845${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -78,7 +79,7 @@ notify :from "notification_test@${defaultdomain.name}"
 	        </t:response>
 	    </t:test>
 	
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cosid}</id>
@@ -88,13 +89,28 @@ notify :from "notification_test@${defaultdomain.name}"
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+       </t:test>
+
 	    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -107,6 +123,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -119,6 +136,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -131,6 +149,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -143,6 +162,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -155,6 +175,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -167,6 +188,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -179,6 +201,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -191,6 +214,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -203,6 +227,7 @@ notify :from "notification_test@${defaultdomain.name}"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -545,7 +570,7 @@ notify :from "notification_test@${defaultdomain.name}"
         </t:test>
     </t:test_case>
     
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -572,5 +597,5 @@ notify :from "notification_test@${defaultdomain.name}"
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->  
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106900.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106900.xml
@@ -8,6 +8,7 @@
     <t:property name="test_notify_account3.name" value="notify3.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_notify_account4.name" value="notify4.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos106900${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -83,7 +84,7 @@ notify :message "notification_msg4"
 	        </t:response>
 	    </t:test>
 	
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cosid}</id>
@@ -93,13 +94,27 @@ notify :message "notification_msg4"
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+       </t:test>
 	    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -112,6 +127,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -125,6 +141,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -137,6 +154,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -150,6 +168,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -162,6 +181,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -175,6 +195,7 @@ notify :message "notification_msg4"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -207,6 +228,8 @@ notify :message "notification_msg4"
                 <t:select path="//admin:ModifyAccountResponse/admin:account"/>
             </t:response>
         </t:test>
+       
+        <t:delay sec="10" />
 
         <t:test>
             <t:request>
@@ -428,7 +451,7 @@ notify :message "notification_msg4"
         </t:test>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -455,5 +478,5 @@ notify :message "notification_msg4"
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106993.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106993.xml
@@ -125,6 +125,8 @@
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107212.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107212.xml
@@ -12,6 +12,7 @@
 <t:property name="test_account10.name" value="test10.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account11.name" value="test11.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account12.name" value="test12.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos107212${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Sieve Mail" />
 <t:property name="msg01.file" value="${testMailRaw.root}/bug107212/mime1.txt"/>
@@ -98,7 +99,7 @@ log "Sieve rule 11";
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -120,13 +121,27 @@ log "Sieve rule 11";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+       </t:test>
 	                
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -140,6 +155,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -153,6 +169,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -166,6 +183,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -180,6 +198,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -193,6 +212,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -206,6 +226,7 @@ log "Sieve rule 11";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -218,7 +239,8 @@ log "Sieve rule 11";
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account8.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>                
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -231,7 +253,8 @@ log "Sieve rule 11";
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account9.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>              
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -244,7 +267,8 @@ log "Sieve rule 11";
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account10.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>                
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -257,7 +281,8 @@ log "Sieve rule 11";
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account11.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>                
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -270,7 +295,8 @@ log "Sieve rule 11";
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account12.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>               
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -1163,7 +1189,7 @@ log "Sieve rule 11";
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount" csrfTokenSecured="0">
 					<account by="name">${test_account12.name}</account>
-					<password>accountpassword</password>
+					<password>${defaultpassword.value}</password>
 				</AuthRequest>
 			</t:request>
 			<t:response>
@@ -1196,7 +1222,7 @@ log "Sieve rule 11";
 		</t:resttest>
 	</t:test_case>	     
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -1223,5 +1249,5 @@ log "Sieve rule 11";
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->   
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107330.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107330.xml
@@ -15,6 +15,7 @@
     <t:property name="test_account6.name" value="test6_${address_prefix}$\{sample}${address_suffix}${account_partial}@${defaultdomain.name}" />
     <t:property name="account_partial2" value=".${TIME}.${COUNTER}" />
     <t:property name="test_redirect_account6.name" value="redirect6_${address_prefix}$\{sample}${address_suffix}${account_partial}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107330${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -154,7 +155,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
         </t:test>
     </t:test_case>
 
-    <t:test_case testcaseid="GlobalConfigSetup" type="always">
+    <!--<t:test_case testcaseid="GlobalConfigSetup" type="always">
         <t:objective>set globalconfig and restart mailboxd</t:objective>
         <t:test required="true">
             <t:request>
@@ -186,7 +187,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
         </t:test>
 
 
-    </t:test_case>
+    </t:test_case>-->
 
     <t:test_case testcaseid="AcctSetup1_create_account" type="always">
         <t:objective>create test accounts</t:objective>
@@ -202,7 +203,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -225,13 +226,28 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-        
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
+ 
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -245,6 +261,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -258,6 +275,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -271,6 +289,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -284,6 +303,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -296,6 +316,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5_1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -308,6 +329,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5_2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule5}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -321,6 +343,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule6}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -334,6 +357,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_redirect_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -810,7 +834,7 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
         </t:test>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig</t:objective>
         <t:test required="true">
             <t:request>
@@ -847,5 +871,5 @@ ereject "${prefix}${dollar_variable}{sample}${suffix}";
 	        </t:response>
 	    </t:test>
     
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107379.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107379.xml
@@ -217,6 +217,8 @@ stop;
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107562.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107562.xml
@@ -3,6 +3,7 @@
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107562${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -123,7 +124,7 @@ if  header :contains ["Subject"] "require abc def" {&#010;
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -145,13 +146,27 @@ if  header :contains ["Subject"] "require abc def" {&#010;
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+       
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                     <name xmlns="">${cos.name}</name>
+                     <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -164,6 +179,7 @@ if  header :contains ["Subject"] "require abc def" {&#010;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -176,6 +192,7 @@ if  header :contains ["Subject"] "require abc def" {&#010;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -227,6 +244,8 @@ if  header :contains ["Subject"] "require abc def" {&#010;
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="sendmsg1.id" />
             </t:response>
         </t:test>
+
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -297,6 +316,8 @@ if  header :contains ["Subject"] "require abc def" {&#010;
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="sendmsg2.id" />
             </t:response>
         </t:test>
+
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -391,6 +412,8 @@ if  header :contains ["Subject"] "require abc def" {&#010;
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">
@@ -441,7 +464,7 @@ if  header :contains ["Subject"] "require abc def" {&#010;
     </t:test_case>
 
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -468,5 +491,5 @@ if  header :contains ["Subject"] "require abc def" {&#010;
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->   
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug28832.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug28832.xml
@@ -1010,7 +1010,7 @@ if anyof (
 	        
 </t:test_case>
 
-<t:test_case testcaseid="bug28832_disable_sieve" type="bhr" bugids="28832">
+<t:test_case testcaseid="bug28832_disable_sieve" type="functional" bugids="28832">
    <t:objective>Mail filter misses the 'reject' action</t:objective>
     <steps> 
         1. Add sieve rule for the user
@@ -1119,7 +1119,7 @@ if anyof (
     </t:test>		        
 </t:test_case>
 
-<t:finally>
+<!--<t:finally>
 
 	<t:test required="true">
 		<t:request>
@@ -1144,6 +1144,6 @@ if anyof (
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
 	    </t:test>        
-</t:finally>
+</t:finally>-->
 
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug31446.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug31446.xml
@@ -12,6 +12,7 @@
 <t:property name="dl1.member1.name" value="mem1.${TIME}.${COUNTER}@${defaultdomain.name}"/>
 <t:property name="dl1.member2.name" value="mem2.${TIME}.${COUNTER}@${defaultdomain.name}"/>
 <t:property name="account1.dl1.name" value="dl1.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+<t:property name="cos.name" value="cos31446${TIME}${COUNTER}" />
 
 <t:property name="notify_account2.name" value="notify2.${TIME}.${COUNTER}@${defaultdomain.name}" />
 
@@ -102,7 +103,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -124,13 +125,28 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
+
 	        
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -144,6 +160,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -157,6 +174,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -170,6 +188,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -183,6 +202,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -196,6 +216,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -209,6 +230,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -222,6 +244,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account8.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -235,6 +258,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account9.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -917,7 +941,7 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
 
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -944,5 +968,5 @@ addheader :last "${variable.name.varname}" "${variable.name.varvalue}";
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug71457.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug71457.xml
@@ -47,6 +47,7 @@
 <t:property name="notify.inline_subject" value="Imp Notification message"/>
 <t:property name="notify.mailto" value="test of adding Server via SOAP"/>
 <t:property name="notify.body" value="This is the notification email alert"/>
+<t:property name="cos.name" value="cos71457${TIME}${COUNTER}" />
 
 <t:property name="sieve_rule1" value='require ["enotify", "fileinto", "variables"];
 if header :contains ["From"] "${test_account1.name}" {
@@ -119,7 +120,7 @@ stop;
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -141,13 +142,27 @@ stop;
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 	    	                
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -161,6 +176,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -174,6 +190,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -187,6 +204,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -200,6 +218,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -213,6 +232,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -226,6 +246,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -238,7 +259,8 @@ stop;
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account8.name}</name>
-                <password>${defaultpassword.value}</password>                
+                <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>               
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -252,6 +274,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account9.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -265,6 +288,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account10.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -278,6 +302,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account11.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -292,6 +317,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -305,6 +331,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -318,6 +345,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -331,6 +359,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -344,6 +373,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account6_1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -357,6 +387,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account6_2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -370,6 +401,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -383,6 +415,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account8_1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -396,6 +429,7 @@ stop;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${notify_account8_2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -1275,7 +1309,7 @@ stop;
 	             
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -1302,6 +1336,6 @@ stop;
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
               
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/EditHeaders.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/EditHeaders.xml
@@ -7,6 +7,7 @@
 <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account5.name" value="test5.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account6.name" value="test6.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos1${TIME}${COUNTER}" />
 
 <t:property name="folder_inbox" value="Inbox" />
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-861/msg01.txt" />
@@ -87,7 +88,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -109,13 +110,27 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 
-		<t:test required="true">
+        <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+       </t:test>
+
+        <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -128,6 +143,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -141,6 +157,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -154,6 +171,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -167,6 +185,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -180,6 +199,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule5}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -193,6 +213,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule6}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -598,7 +619,7 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
         </t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -625,5 +646,5 @@ deleteheader :matches "X-HeaderZ" "sample\\\\\\\\\\\\\\\\\\\\pattern";
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/MatchVariables.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/MatchVariables.xml
@@ -31,6 +31,7 @@
 	<t:property name="tag2_expected" value="e" />
 	<t:property name="tag3_expected" value="e" />
 	<t:property name="tag4_expected" value="Seive Test DeMo To Be Executed 5" />
+        <t:property name="cos.name" value="cos1${TIME}${COUNTER}" />
 	
 	<t:property name="sieve_test1"
 		value='require ["log","fileinto","relational","variables"];	
@@ -130,7 +131,7 @@
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -152,13 +153,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	    
+                <t:test id="CreateCosRequest1">
+        	    <t:request>
+                        <CreateCosRequest xmlns="urn:zimbraAdmin">
+                            <name xmlns="">${cos.name}</name>
+                            <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                        </CreateCosRequest>
+                    </t:request>
+                    <t:response>
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                    </t:response>
+                </t:test>
+
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -982,6 +997,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -995,6 +1011,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1008,6 +1025,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1021,6 +1039,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1034,6 +1053,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule5}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1047,6 +1067,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule6}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1060,6 +1081,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account7.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule7}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1073,6 +1095,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account8.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule8}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1086,6 +1109,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account9.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule9}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1099,6 +1123,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account10.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule10}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1112,6 +1137,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account11.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule11}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1125,6 +1151,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account12.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule12}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1138,6 +1165,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${zcs616_account13.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraMailSieveScript">${sieve_rule13}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1896,7 +1924,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
 		value="test14.${TIME}.${COUNTER}@${defaultdomain.name}" />
 	<t:property name="account15.name"
 		value="test15.${TIME}.${COUNTER}@${defaultdomain.name}" />
-	<t:property name="Subject" value="${defaultpassword.value}" />
+	<t:property name="Subject" value="test123" />
 	<t:property name="00009" value="$\{00009}" />
 	<t:property name="00002" value="$\{00002}" />
 	<t:property name="000004" value="$\{000004}" />
@@ -1938,6 +1966,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account14.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_test14}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -1950,6 +1979,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account15.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_test15}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -2103,7 +2133,7 @@ if header :contains "Subject" "sieve\\\\\\\\test"
 		</t:resttest>
 	</t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -2130,5 +2160,5 @@ if header :contains "Subject" "sieve\\\\\\\\test"
 	        </t:response>
 	    </t:test>
 
-    </t:finally>	
+    </t:finally>-->	
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1006-AsciiNumericNegativNumber.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1006-AsciiNumericNegativNumber.xml
@@ -1,6 +1,7 @@
 <t:tests xmlns:t="urn:zimbraTestHarness">
     <!-- Test accounts declaration -->
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos1006${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="text"       value="$\{text}"/>
@@ -23,7 +24,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -45,13 +46,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-	    
+	    </t:test>-->
+	 
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+       </t:test>
+   
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -61,7 +76,7 @@
         </t:test>
     </t:test_case>
 
-    <t:test_case testcaseid="configSetup1" type="always">
+    <!--<t:test_case testcaseid="configSetup1" type="always">
         <t:test required="true">
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAdmin">
@@ -87,7 +102,7 @@
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
         </t:test>
-    </t:test_case>
+    </t:test_case>-->
 
 
     <t:test_case testcaseid="ZCS-1006_string-is" type="bhr" bugids="ZCS-1006">
@@ -1751,6 +1766,8 @@ tag "always-${labe_deleteheader_value_rule0601}";
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">
@@ -1767,7 +1784,7 @@ tag "always-${labe_deleteheader_value_rule0601}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_deleteheader_value_rule0601}</query>
+					<query>in:Inbox subject:"${labe_deleteheader_value_rule0601}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -1842,6 +1859,8 @@ tag "always-${labe_deleteheader_value_rule0602}";
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="msg1.id" />
             </t:response>
         </t:test>
+        
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -1859,7 +1878,7 @@ tag "always-${labe_deleteheader_value_rule0602}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_deleteheader_value_rule0602}</query>
+					<query>in:Inbox subject:"${labe_deleteheader_value_rule0602}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -1935,6 +1954,8 @@ tag "always-${labe_deleteheader_value_rule0603}";
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">
@@ -1951,7 +1972,7 @@ tag "always-${labe_deleteheader_value_rule0603}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_deleteheader_value_rule0603}</query>
+					<query>in:Inbox subject:"${labe_deleteheader_value_rule0603}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -2037,6 +2058,8 @@ tag "always-${labe_replaceheader_value_rule0701}";
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="msg1.id" />
             </t:response>
         </t:test>
+        
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -2054,7 +2077,7 @@ tag "always-${labe_replaceheader_value_rule0701}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_replaceheader_value_rule0701}</query>
+					<query>in:Inbox subject:"${labe_replaceheader_value_rule0701}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -2131,6 +2154,8 @@ tag "always-${labe_replaceheader_value_rule0702}";
             </t:response>
         </t:test>
 
+        <t:delay sec="5" />
+
         <t:test>
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAccount">
@@ -2147,7 +2172,7 @@ tag "always-${labe_replaceheader_value_rule0702}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_replaceheader_value_rule0702}</query>
+					<query>in:Inbox subject:"${labe_replaceheader_value_rule0702}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -2223,6 +2248,7 @@ tag "always-${labe_replaceheader_value_rule0703}";
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="msg1.id" />
             </t:response>
         </t:test>
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -2240,7 +2266,7 @@ tag "always-${labe_replaceheader_value_rule0703}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_replaceheader_value_rule0703}</query>
+					<query>in:Inbox subject:"${labe_replaceheader_value_rule0703}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -2316,6 +2342,8 @@ tag "always-${labe_replaceheader_value_rule0704}";
                 <t:select path="//mail:SendMsgResponse/mail:m" attr="id" set="msg1.id" />
             </t:response>
         </t:test>
+        
+        <t:delay sec="5" />
 
         <t:test>
             <t:request>
@@ -2333,7 +2361,7 @@ tag "always-${labe_replaceheader_value_rule0704}";
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">
-					<query>in:Inbox subject:${labe_replaceheader_value_rule0704}</query>
+					<query>in:Inbox subject:"${labe_replaceheader_value_rule0704}"</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -2353,7 +2381,7 @@ tag "always-${labe_replaceheader_value_rule0704}";
 		</t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -2380,5 +2408,5 @@ tag "always-${labe_replaceheader_value_rule0704}";
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->   
 </t:tests>


### PR DESCRIPTION
- Used new COS instead of modifying existing COS
- Moved Modify Global config to setup script handled by zm-continuous-integration and commented out modifyconfig test steps. See companion PR https://github.com/ZimbraOS/zm-continuous-integration/pull/140
- Added delays for cases where sieve rule was not getting applied due to delay in lmtp
- Fixed other script issues

Note:
More Sieve tests are to be analysed and fixed.