### PR TITLE
ZCS-10083 fixed calendar bhr tests

### DIFF
--- a/data/soapvalidator/Calendar/Appointments/CancelAppointmentRequest-RecurrenceDaily.xml
+++ b/data/soapvalidator/Calendar/Appointments/CancelAppointmentRequest-RecurrenceDaily.xml
@@ -66,7 +66,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="436582" type="smoke" areas="Calendar">
+<t:test_case testcaseid="436582" type="bhr" areas="Calendar">
     <t:objective>Delete This Inline repeating event</t:objective>
 <t:steps> 1. create an daily recurring appointment.  5 occurrences.
 		  2. Delete 3rd instance of that appt.

--- a/data/soapvalidator/Calendar/Appointments/ForwardAppointmentInviteRequest-Basic.xml
+++ b/data/soapvalidator/Calendar/Appointments/ForwardAppointmentInviteRequest-Basic.xml
@@ -323,7 +323,9 @@
 			<t:select path="//mail:ForwardAppointmentInviteResponse" />
 		</t:response>
 	</t:test>
-        <t:delay sec="60"/>	
+
+   <t:delay sec="60"/>
+
 	<t:property name="server.zimbraAccount" value="${account1.server}"/>
    <t:test>
         <t:request>

--- a/data/soapvalidator/Calendar/Appointments/ForwardAppointmentInviteRequest-Basic.xml
+++ b/data/soapvalidator/Calendar/Appointments/ForwardAppointmentInviteRequest-Basic.xml
@@ -108,7 +108,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="ForwardAppointmentInviteRequest01" type="smoke">
+<t:test_case testcaseid="ForwardAppointmentInviteRequest01" type="bhr">
 <t:objective>Forward appointment Invitation from one attendee to third user   </t:objective>
 
 	<t:property name="server.zimbraAccount" value="${account1.server}"/>
@@ -323,7 +323,7 @@
 			<t:select path="//mail:ForwardAppointmentInviteResponse" />
 		</t:response>
 	</t:test>
-	
+        <t:delay sec="60"/>	
 	<t:property name="server.zimbraAccount" value="${account1.server}"/>
    <t:test>
         <t:request>

--- a/data/soapvalidator/Calendar/Appointments/Workflow/Calendar-SendInviteReply.xml
+++ b/data/soapvalidator/Calendar/Appointments/Workflow/Calendar-SendInviteReply.xml
@@ -267,7 +267,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="SendInviteReplyRequest1" type="smoke">
+<t:test_case testcaseid="SendInviteReplyRequest1" type="bhr">
     <t:objective>Accepting invitation request</t:objective>    
     <t:steps>1. Search the invitation
              2. Accept it
@@ -293,7 +293,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="SendInviteReplyRequest2" type="smoke">
+<t:test_case testcaseid="SendInviteReplyRequest2" type="bhr">
     <t:objective>Declining invitation request</t:objective>
     <t:steps>1. Search the invitation
              2. Decline it

--- a/data/soapvalidator/Calendar/Bugs/Bug26407.xml
+++ b/data/soapvalidator/Calendar/Bugs/Bug26407.xml
@@ -22,7 +22,7 @@
 
 <t:property name="timezone.pst" value="(GMT-08.00) Pacific Time (US &amp; Canada)"/>
 
-<t:property name="time.08Jul2020100000.gmt" value="1594170000000"/>
+<t:property name="time.08Jul2020100000.gmt" value="1640977237000"/>
 <t:property name="time.08Jul2020100000.pst" value="${TIME(-8h)[${time.08Jul2020100000.gmt}]}"/>
 
 <t:property name="TimeRangeStart" value="${TIME(-3d)[${time.08Jul2020100000.pst}]}"/>

--- a/data/soapvalidator/Calendar/Bugs/Bug62417.xml
+++ b/data/soapvalidator/Calendar/Bugs/Bug62417.xml
@@ -124,7 +124,7 @@
 
    
     <t:property name="appt1.timezone" value="${timezone5}"/>
-    <t:property name="appt1.start.gmt" value="1577880000000"/>						<!-- 1/1/2010 12:00:00 -->
+    <t:property name="appt1.start.gmt" value="1640977237000"/>						<!-- 1/1/2010 12:00:00 -->
     <t:property name="appt1.start.pst" value="${TIME(-8h)[${appt1.start.gmt}]}"/>	<!-- 1/1/2010 04:00:00 -->
     <t:property name="appt1.subject" value="subject.${TIME}.${COUNTER}"/>
     <t:property name="appt1.content" value="content.${TIME}.${COUNTER}"/>

--- a/data/soapvalidator/Calendar/Bugs/Bug71713.xml
+++ b/data/soapvalidator/Calendar/Bugs/Bug71713.xml
@@ -157,7 +157,7 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
-    
+    <t:delay sec="20"/> 
      <t:test >
         <t:request>
             <GetMsgRequest xmlns="urn:zimbraMail">
@@ -227,7 +227,7 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
-    
+    <t:delay sec="20"/>
     <t:test >
       <t:request>
         <CounterAppointmentRequest xmlns="urn:zimbraMail" id="${appt_id}" ms="${ms}" rev="${rev}">

--- a/data/soapvalidator/Calendar/Bugs/Bug71713.xml
+++ b/data/soapvalidator/Calendar/Bugs/Bug71713.xml
@@ -157,8 +157,10 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
-    <t:delay sec="20"/> 
-     <t:test >
+
+    <t:delay sec="20"/>
+
+    <t:test>
         <t:request>
             <GetMsgRequest xmlns="urn:zimbraMail">
                 <m id="${appointment1.id}" />
@@ -227,7 +229,9 @@
             <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
         </t:response>
     </t:test>
+
     <t:delay sec="20"/>
+
     <t:test >
       <t:request>
         <CounterAppointmentRequest xmlns="urn:zimbraMail" id="${appt_id}" ms="${ms}" rev="${rev}">


### PR DESCRIPTION
Fixed following calendar bhr tests.

-build/temp/data/soapvalidator/Calendar/Bugs/Bug26407.xml----  Fixed : Need to put future date
-build/temp/data/soapvalidator/Calendar/Bugs/Bug62417.xml---   Fixed : Need to put future date   
-build/temp/data/soapvalidator/Calendar/Bugs/Bug71713.xml--      Fixed  Add Delay  of 20 sec  before GetMsgRequest and CounterAppointmentRequest.
-build/temp/data/soapvalidator/Calendar/Appointments/CancelAppointmentRequest-RecurrenceDaily.xml : Replaced smoke to bhr 
-build/temp/data/soapvalidator/Calendar/Appointments/ForwardAppointmentInviteRequest-Basic.xml : Add delay before GetAppointment Request.
-build/temp/data/soapvalidator/Calendar/Appointments/Workflow/Calendar-SendInviteReply.xml: : Replaced smoke to bhr