### PR TITLE
ZCS-10090 Fixed some Contacts script and added some tests in skipped file

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -22,6 +22,12 @@ build/temp/data/soapvalidator/Calendar/Appointments/Workflow/New-Calendar-SendIn
 build/temp/data/soapvalidator/Calendar/MeetingRequest/CancelMeetingRequest-Basic.xml
 build/temp/data/soapvalidator/Calendar/MeetingRequest/CreateMeetingRequest-Reminder.xml
 build/temp/data/soapvalidator/Calendar/SnoozeCalendarItemAlarmRequest.xml
+#Test case is wrong
+build/temp/data/soapvalidator/Calendar/Bugs/Bug60181.xml
+build/temp/data/soapvalidator/Calendar/Bugs/Bug33613.xml
+build/temp/data/soapvalidator/Calendar/Bugs/Bug34412.xml
+#Timezone issue
+build/temp/data/soapvalidator/Calendar/Appointments/CreateAppointmentRequest-Private.xml
 build/temp/data/soapvalidator/Contacts/AutoComplete/AutoComplete-GALandSharedContacts.xml
 build/temp/data/soapvalidator/Contacts/AutoComplete/AutoCompleteLucene.xml
 build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/RankingActionRequest-Delete.xml
@@ -44,6 +50,15 @@ build/temp/data/soapvalidator/Contacts/AutoComplete/AutoCompleteRequesti18n.xml
 #ZCS-6163
 build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/AutoComplete-GAL-Ranking.xml
 build/temp/data/soapvalidator/Prefs/Filters/Sieve/Notification.xml
+#ZCS-7999
+build/temp/data/soapvalidator/Contacts/AutoComplete/AutoCompleteRequest.xml
+#ZCS-6163
+build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/AutoComplete-Ranking.xml
+build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/RankingActionRequest-Reset.xml
+#ZCS-5153
+build/temp/data/soapvalidator/Contacts/Bugs/Bug48742.xml
+#ZCS-5167
+build/temp/data/soapvalidator/Contacts/Bugs/Bug74468.xml
 
 # STAF dependency - convert STAF commands to use kubectl.
 build/temp/data/soapvalidator/Admin/ACL/ACL-Basic.xml

--- a/data/soapvalidator/Contacts/AutoComplete/Bug65081.xml
+++ b/data/soapvalidator/Contacts/AutoComplete/Bug65081.xml
@@ -138,6 +138,7 @@
         </t:response>
     </t:test>
 
+	<t:delay sec="20"/>
 	
 	<t:test>
 		<t:request>
@@ -153,6 +154,7 @@
 		</t:response>
     </t:test>  
 
+        <t:delay sec="20"/>
 
 	<t:test>
 		<t:request>
@@ -169,6 +171,7 @@
 		</t:response>
     </t:test>  
 
+        <t:delay sec="20"/>
 
 	<t:test>
 		<t:request>
@@ -185,7 +188,7 @@
 		</t:response>
     </t:test> 
 
-
+	<t:delay sec="60"/>
 	<t:test>
 		<t:request>
 			<AutoCompleteRequest xmlns="urn:zimbraMail"> 


### PR DESCRIPTION

**Added following Contact/Calendar tests in skipped  file.:**

```
build/temp/data/soapvalidator/Calendar/Bugs/Bug33613.xml---Exiting bug-ZCS-6155
build/temp/data/soapvalidator/Calendar/Bugs/Bug34412.xml---Existing bug-ZCS-6155
build/temp/data/soapvalidator/Calendar/Bugs/Bug60181.xml---Test case is wrong
build/temp/data/soapvalidator/Contacts/AutoComplete/AutoCompleteRequest.xml  ---Existing bug :https://jira.corp.synacor.com/browse/ZCS-7999
build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/AutoComplete-Ranking.xml: Existing bug https://jira.corp.synacor.com/browse/ZCS-6163
build/temp/data/soapvalidator/Contacts/AutoComplete/Ranking/RankingActionRequest-Reset.xml Existing bug https://jira.corp.synacor.com/browse/ZCS-6163
build/temp/data/soapvalidator/Contacts/Bugs/Bug48742.xml --- ---Existing bug :https://jira.corp.synacor.com/browse/ZCS-5153
build/temp/data/soapvalidator/Contacts/Bugs/Bug74468.xml---  ---Existing bug: https://jira.corp.synacor.com/browse/ZCS-5167
```

**Fixed**:
build/temp/data/soapvalidator/Contacts/AutoComplete/Bug65081.xml: fixed : Delay required before autocomplete
