### PR TITLE
ZCS-10091: Fixed Sieve testcases which were failing due to config/cos updates not reflecting to account

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -60,6 +60,9 @@ build/temp/data/soapvalidator/Contacts/Bugs/Bug48742.xml
 #ZCS-5167
 build/temp/data/soapvalidator/Contacts/Bugs/Bug74468.xml
 
+# Skipped below as it will overwrite zimbraCustomMimeHeaderNameAllowed and cause other Sieve tests to fail
+build/temp/data/soapvalidator/Mail/CustomHeader/Custom-Header.xml
+ 
 # STAF dependency - convert STAF commands to use kubectl.
 build/temp/data/soapvalidator/Admin/ACL/ACL-Basic.xml
 build/temp/data/soapvalidator/Admin/Bugs/Bug11299.xml

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106870.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106870.xml
@@ -190,6 +190,7 @@
             <t:request>
                 <CreateCosRequest xmlns="urn:zimbraAdmin">
                     <name xmlns="">${cos1.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
                 </CreateCosRequest>
             </t:request>
             <t:response>
@@ -198,7 +199,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cos1.id}</id>
@@ -208,7 +209,7 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	    
 		<t:test required="true">
 			<t:request>
@@ -472,7 +473,7 @@
 		<t:objective>Add a sieve rule to delete custom header and verify the
 			mime via rest servlet</t:objective>
 
-		<t:test>
+		<!--<t:test>
 			<t:request>
 				<ModifyConfigRequest xmlns="urn:zimbraAdmin">
 					<a n="zimbraCustomMimeHeaderNameAllowed">X-Test-Header</a>
@@ -482,7 +483,7 @@
 			<t:response>
 				<t:select path="//admin:ModifyConfigResponse" />
 			</t:response>
-		</t:test>
+		</t:test>-->
 
 		<t:test id="modifyaccountrequest01">
 			<t:request>
@@ -1507,7 +1508,7 @@
 			</t:response>
 		</t:test>
 		
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cos1.id}</id>
@@ -1517,7 +1518,7 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 		
 		<t:test required="true">
 			<t:request>
@@ -1536,6 +1537,7 @@
 				<ModifyAccountRequest xmlns="urn:zimbraAdmin">
 					<id>${test_account13.id}</id>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule14}</a>
+                                        <a n="zimbraSieveImmutableHeaders">${defaultzimbraSieveImmutableHeaders},X-Sieve-Header1</a>
 				</ModifyAccountRequest>
 			</t:request>
 			<t:response>
@@ -1604,7 +1606,7 @@
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cos1.id}</id>
@@ -1614,7 +1616,7 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 		
 	</t:test_case>
  

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107221.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107221.xml
@@ -7,6 +7,7 @@
 <t:property name="test_account5.name" value="test5.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account6.name" value="test6.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account7.name" value="test7.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos107221${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Sieve Mail" />
 <t:property name="msg01.file" value="${testMailRaw.root}/bug107221/mime1.txt"/>
@@ -90,7 +91,7 @@ log "done";'/>
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -112,13 +113,27 @@ log "done";'/>
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 	                
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -132,6 +147,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -145,6 +161,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -158,6 +175,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -172,6 +190,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -185,6 +204,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -198,6 +218,7 @@ log "done";'/>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -769,7 +790,7 @@ log "done";'/>
 
 </t:test_case> 
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -796,5 +817,5 @@ log "done";'/>
 	        </t:response>
 	    </t:test>
 
-    </t:finally>      
+    </t:finally>--> 
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107222.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107222.xml
@@ -4,6 +4,7 @@
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107222${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -50,7 +51,7 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -72,13 +73,28 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
+
 	    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -92,6 +108,7 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -105,6 +122,7 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -118,6 +136,7 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -381,7 +400,7 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
         </t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -408,5 +427,5 @@ replaceheader :newvalue "[追加]: ${dollar1}" :comparator "i;ascii-casemap" :ma
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107321.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107321.xml
@@ -4,6 +4,7 @@
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107321${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -100,7 +101,7 @@ if exists "Subject" {
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -122,13 +123,27 @@ if exists "Subject" {
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-	    
+	    </t:test>-->
+	
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
+    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n = "zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -142,6 +157,7 @@ if exists "Subject" {
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -155,6 +171,7 @@ if exists "Subject" {
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -168,6 +185,7 @@ if exists "Subject" {
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -475,7 +493,7 @@ if exists "Subject" {
         </t:test>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -502,5 +520,5 @@ if exists "Subject" {
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107355.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107355.xml
@@ -2,6 +2,7 @@
     <!-- Test accounts declaration -->
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107355${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -82,7 +83,7 @@ if anyof (header :matches ["X-Test-Header"] "*"){
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -104,13 +105,27 @@ if anyof (header :matches ["X-Test-Header"] "*"){
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -124,6 +139,7 @@ if anyof (header :matches ["X-Test-Header"] "*"){
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -286,7 +302,7 @@ if anyof (header :matches ["X-Test-Header"] "*"){
         </t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -313,5 +329,5 @@ if anyof (header :matches ["X-Test-Header"] "*"){
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->  
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107361.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107361.xml
@@ -3,6 +3,7 @@
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107221${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -45,7 +46,7 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -78,6 +79,19 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
             <t:response>
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
+        </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
         </t:test>
         	    
         <t:test required="true">
@@ -85,6 +99,7 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -98,6 +113,7 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -111,6 +127,7 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -334,7 +351,7 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
         </t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -371,5 +388,5 @@ replaceheader :newvalue "new value" :comparator "i;ascii-casemap" :is "X-Test-He
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
         </t:test>
-    </t:finally>    
+    </t:finally>--> 
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107381.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107381.xml
@@ -22,6 +22,7 @@
     <t:property name="test_notify_account3.name" value="notify3\\*abc\\?123${account_partial_3}" />
     <t:property name="account_partial_4" value=".${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_redirect_account3.name" value="redirect3\\*abc\\?123${account_partial_4}" />
+    <t:property name="cos.name" value="cos107381${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -330,7 +331,7 @@ keep;
         </t:response>
     </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -353,13 +354,28 @@ keep;
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
     
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
+
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -374,6 +390,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -388,6 +405,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -402,6 +420,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -416,6 +435,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule5}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -430,6 +450,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule6}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -444,6 +465,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account7.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule7}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -458,6 +480,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account8.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule8}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -472,6 +495,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account9.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule9}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -486,6 +510,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account10.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule10}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -500,6 +525,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -512,6 +538,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_redirect_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraSpamApplyUserFilters">TRUE</a>
                 </CreateAccountRequest>
             </t:request>
@@ -525,6 +552,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account11.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule11}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -539,6 +567,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -551,6 +580,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_redirect_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraSpamApplyUserFilters">TRUE</a>
                 </CreateAccountRequest>
             </t:request>
@@ -564,6 +594,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account12.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule12}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -578,6 +609,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -590,6 +622,7 @@ keep;
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_redirect_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraSpamApplyUserFilters">TRUE</a>
                 </CreateAccountRequest>
             </t:request>
@@ -1510,7 +1543,7 @@ keep;
         </t:test>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -1538,6 +1571,6 @@ keep;
         </t:response>
     </t:test>
 
-    </t:finally>
+    </t:finally>-->
     
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug107615.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug107615.xml
@@ -6,6 +6,7 @@
     <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account5.name" value="test5.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account6.name" value="test6.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos107615${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -42,7 +43,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
         </t:test>
     </t:test_case>
 
-    <t:test_case testcaseid="GlobalConfigSetup" type="bhr">
+    <!--<t:test_case testcaseid="GlobalConfigSetup" type="bhr">
         <t:objective>set globalconfig</t:objective>
         <t:test required="true">
             <t:request>
@@ -56,7 +57,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
             </t:response>
         </t:test>
 	    
-	    <t:test>
+	    <<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -90,7 +91,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
         </t:test>
-    </t:test_case>
+    </t:test_case>-->
 
     <t:test_case testcaseid="AcctSetup1_create_account" type="bhr">
         <t:objective>create test accounts</t:objective>
@@ -105,12 +106,27 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
             </t:response>
         </t:test>
+        
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
+
 
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -124,6 +140,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -137,6 +154,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -150,6 +168,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -163,6 +182,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -175,6 +195,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -591,7 +612,7 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
         </t:resttest>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset globalconfig</t:objective>
         <t:test required="true">
             <t:request>
@@ -627,5 +648,5 @@ deleteheader :matches "X-Test-Header" "NOT_MATCHED";
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
         </t:test>
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1088-DetectSpacesInHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1088-DetectSpacesInHeader.xml
@@ -64,6 +64,8 @@
  <t:property name="test_account22_notify.name"
   value="test22_notify.${TIME}.${COUNTER}@${defaultdomain.name}" />
 
+ <t:property name="cos.name" value="cos1088${TIME}${COUNTER}" />
+
  <t:property name="mail_subject" value="Sieve Mail" />
  <t:property name="val" value="$\{1}" />
  <t:property name="msg01.file" value="${testMailRaw.root}/bug104314/mime1.txt" />
@@ -211,7 +213,7 @@ log "Replace header 8 done";' />
    </t:response>
   </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -234,13 +236,28 @@ log "Replace header 8 done";' />
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+  <t:test id="CreateCosRequest1">
+      <t:request>
+          <CreateCosRequest xmlns="urn:zimbraAdmin">
+              <name xmlns="">${cos.name}</name>
+              <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+              <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+          </CreateCosRequest>
+      </t:request>
+      <t:response>
+          <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+          <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+      </t:response>
+  </t:test>
 	    
   <t:test required="true">
    <t:request>
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account1.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -257,6 +274,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account2.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -273,6 +291,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account3.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -289,6 +308,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account4.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -304,6 +324,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account5.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -319,6 +340,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account6.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -334,6 +356,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account7.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -349,6 +372,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account8.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -364,6 +388,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account9.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -379,6 +404,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account10.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -394,6 +420,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account11.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -409,6 +436,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account12.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -424,6 +452,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account13.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -439,6 +468,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account16.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -455,6 +485,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account17.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -471,6 +502,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account18.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -487,6 +519,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account19.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -503,6 +536,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account20.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -519,6 +553,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account20_notify.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -535,6 +570,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account21.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -551,6 +587,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account21_notify.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -567,6 +604,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account22.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -583,6 +621,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account22_notify.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -599,6 +638,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account23.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -615,6 +655,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account24.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -631,6 +672,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account25.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -647,6 +689,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account26.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -663,6 +706,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account27.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -679,6 +723,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account28.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -695,6 +740,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account29.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -711,6 +757,7 @@ log "Replace header 8 done";' />
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${test_account30.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -2181,7 +2228,7 @@ tag "${label16}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">X-Test-Header</a>
@@ -2190,7 +2237,7 @@ tag "${label16}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2310,7 +2357,7 @@ tag "${label17}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">NewHeader</a>
@@ -2319,7 +2366,7 @@ tag "${label17}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2432,7 +2479,7 @@ tag "${label18}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">New Header</a>
@@ -2442,7 +2489,7 @@ tag "${label18}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2555,7 +2602,7 @@ tag "${label19}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">NewHeader</a>
@@ -2565,7 +2612,7 @@ tag "${label19}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2677,7 +2724,7 @@ tag "${label20}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">X-Priority</a>
@@ -2686,7 +2733,7 @@ tag "${label20}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2821,7 +2868,7 @@ tag "${label21}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">X-Priority</a>
@@ -2830,7 +2877,7 @@ tag "${label21}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -2965,7 +3012,7 @@ tag "${label22}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">X-Priority</a>
@@ -2974,7 +3021,7 @@ tag "${label22}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -3900,7 +3947,7 @@ tag "${label30}";
    </t:response>
   </t:test>
 
-  <t:test>
+  <!--<t:test>
    <t:request>
     <ModifyConfigRequest xmlns="urn:zimbraAdmin">
      <a n="zimbraCustomMimeHeaderNameAllowed">This is </a>
@@ -3909,7 +3956,7 @@ tag "${label30}";
    <t:response>
     <t:select path="//admin:ModifyConfigResponse" />
    </t:response>
-  </t:test>
+  </t:test>-->
 
   <t:test id="modifyaccountrequest1">
    <t:request>
@@ -3979,7 +4026,7 @@ tag "${label30}";
  </t:test_case>
 
 
- <t:finally>
+ <!--<t:finally>
   <t:test required="false">
    <t:request>
     <AuthRequest xmlns="urn:zimbraAdmin">
@@ -4017,5 +4064,5 @@ tag "${label30}";
 	        </t:response>
 	    </t:test>
 	    
- </t:finally> 
+ </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1238-MatchVariables.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1238-MatchVariables.xml
@@ -6,6 +6,7 @@
 
 	<t:property name="account1.name"
 		value="sieve1238.${TIME}${COUNTER}@${defaultdomain.name}" />
+        <t:property name="cos.name" value="cos107221${TIME}${COUNTER}" />
 	<t:property name="subject1" value="sub1.${TIME}${COUNTER}" />
 	<t:property name="subject2" value="sub2.${TIME}${COUNTER}" />
 	<t:property name="subject3" value="sub3.${TIME}${COUNTER}" />
@@ -64,7 +65,7 @@
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -86,13 +87,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+                <t:test id="CreateCosRequest1">
+                    <t:request>
+                        <CreateCosRequest xmlns="urn:zimbraAdmin">
+                            <name xmlns="">${cos.name}</name>
+                            <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                        </CreateCosRequest>
+                    </t:request>
+                    <t:response>
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                    </t:response>
+                </t:test>
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -379,7 +394,7 @@
 
 	</t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -406,5 +421,5 @@
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1287.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1287.xml
@@ -13,6 +13,7 @@
 	<t:property name="test_account7.name" value="test7.${TIME}.${COUNTER}@${defaultdomain.name}" />
 	<t:property name="test_account8.name" value="test8.${TIME}.${COUNTER}@${defaultdomain.name}" />
 	<t:property name="test_account9.name" value="test9.${TIME}.${COUNTER}@${defaultdomain.name}" />
+        <t:property name="cos.name" value="cos1287${TIME}${COUNTER}" />
 	
 	<t:property name="variable_from" value="$\{from}"></t:property>
 	<t:property name="variable_subject" value="$\{subject}"></t:property>
@@ -23,8 +24,8 @@
 	<t:property name="mail_subject_1" value="mail_subject"></t:property>
 	<t:property name="mail_content" value="Hi,\\rYou have got a mail!\\r."></t:property>
 	<t:property name="msg01.file" value="${testMailRaw.root}/zcs-1287/mime1.txt" />
-	<t:property name="msg02.file" value="${testMailRaw.root}/zcs-1287/blank_mime.txt" />
-	<t:property name="msg03.file" value="${testMailRaw.root}/zcs-1287/tag_mime.txt" />
+	<t:property name="msg02.file" value="${testMailRaw.root}/zcs-1287/blank-mime.txt" />
+	<t:property name="msg03.file" value="${testMailRaw.root}/zcs-1287/tag-mime.txt" />
 	
 	<t:property name="sieve_rule1" value='require ["enotify", "variables"];
 		set "from" "abc@abc.com";
@@ -92,7 +93,7 @@
 			</t:response>
 		</t:test>
 
-	     <t:test>
+	     <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -114,13 +115,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test> 
+	    </t:test>-->
+
+                <t:test id="CreateCosRequest1">
+                    <t:request>
+                        <CreateCosRequest xmlns="urn:zimbraAdmin">
+                            <name xmlns="">${cos.name}</name>
+                            <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                        </CreateCosRequest>
+                </t:request>
+                <t:response>
+                    <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                    <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                </t:response>
+                </t:test> 
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule1}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -135,6 +150,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -147,6 +163,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -164,6 +181,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -176,6 +194,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule3}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -193,6 +212,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -205,6 +225,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account4.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule4}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -219,6 +240,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify4.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -231,6 +253,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account5.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptAfter">${sieve_rule5}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -245,6 +268,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account6.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule5}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -262,6 +286,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account7.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule6}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -279,6 +304,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account8.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule6}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -296,6 +322,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account9.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule7}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -487,7 +514,7 @@
 			</t:response>
 		</t:test> 
 
-	</t:test_case>	
+	</t:test_case>
 	
  	<t:test_case testcaseid="zcs-1287_rule4" type="bhr" bugids="zcs-1287">
 		<t:objective>Verify notify email id is set to the recipient if invalid :from is set in rule</t:objective>
@@ -848,7 +875,7 @@
 
 	</t:test_case>
 				 		
-     <t:finally type="always">
+     <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -875,6 +902,6 @@
 	        </t:response>
 	    </t:test>
 
-    </t:finally> 
+    </t:finally>-->
     		
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1845.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1845.xml
@@ -5,7 +5,8 @@
 <t:property name="account2.name"
 		value="test2_${TIME}${COUNTER}@${defaultdomain.name}" />
 <t:property name="account3.name"
-		value="test3_${TIME}${COUNTER}@${defaultdomain.name}" />		
+		value="test3_${TIME}${COUNTER}@${defaultdomain.name}" />	
+<t:property name="cos.name" value="cos1845${TIME}${COUNTER}" />	
 
 <!-- Variables declaration -->		
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-1845/mime01.txt" />
@@ -70,7 +71,7 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
             </t:response>
      </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -92,13 +93,28 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    	
 	<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -112,6 +128,7 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -125,6 +142,7 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -345,7 +363,7 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
 		</t:resttest>
 	</t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -372,5 +390,5 @@ if header :matches "To" "test3_*@${defaultdomain.name}" {
 	        </t:response>
 	    </t:test>
 
-    </t:finally>	
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-2473-Matches-For-Malencoded-Header.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-2473-Matches-For-Malencoded-Header.xml
@@ -4,6 +4,7 @@
 <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos2473${TIME}${COUNTER}" />
 
 <t:property name="folder_inbox" value="Inbox" />
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-2473/msg01.txt" />
@@ -66,7 +67,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -88,13 +89,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -108,6 +123,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule2}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -121,6 +137,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule3}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -134,6 +151,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptAfter">${sieve_rule4}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -384,7 +402,7 @@
     </t:test_case>
 
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
 
         <t:test required="true">
@@ -410,5 +428,5 @@
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>
 	        </t:response>
 	    </t:test>
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/AddHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/AddHeader.xml
@@ -8,6 +8,7 @@
 <t:property name="account6.name" value="test6.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account7.name" value="test7.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="outgoing.name" value="outgoing.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos273-2${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Sieve Mail" />
 
@@ -42,7 +43,7 @@
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -64,16 +65,30 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	    
 	<!-- Remember these values for later -->
 	<t:property name="authToken.admin" value="${authToken}"/>
+    
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -87,6 +102,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -100,6 +116,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -113,6 +130,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -126,6 +144,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -139,6 +158,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -152,6 +172,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -165,6 +186,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${outgoing.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -964,7 +986,7 @@
 		</t:resttest>				    
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -991,5 +1013,5 @@
 	        </t:response>
 	    </t:test>
 		
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/DeleteHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/DeleteHeader.xml
@@ -21,6 +21,7 @@
 <t:property name="account19.name" value="test19.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account20.name" value="test20.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="outgoing.name" value="outgoing.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos273-1${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Sieve Mail" />
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-273/mime1.txt"/>
@@ -60,7 +61,7 @@
 	<!-- Remember these values for later -->
 	<t:property name="authToken.admin" value="${authToken}"/>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -93,13 +94,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 	    
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -113,6 +128,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -126,6 +142,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -139,6 +156,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -152,6 +170,7 @@
     	<CreateAccountRequest xmlns="urn:zimbraAdmin">
      		<name>${account5.name}</name>
      		<password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
     	</CreateAccountRequest>
    	</t:request>
    <t:response>
@@ -165,6 +184,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account6.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -181,6 +201,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account7.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -197,6 +218,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account8.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -213,6 +235,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account9.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -229,6 +252,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account10.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -245,6 +269,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account11.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -261,6 +286,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account12.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -277,6 +303,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account13.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -293,6 +320,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account14.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -309,6 +337,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account15.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -325,6 +354,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account16.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -341,6 +371,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account17.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -357,6 +388,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account18.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -373,6 +405,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account19.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -389,6 +422,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account20.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -405,6 +439,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${outgoing.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -2759,7 +2794,7 @@
     </t:test>                	    
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -2797,5 +2832,5 @@
 			</t:response>
 		</t:test>
 		
-    </t:finally> 
+    </t:finally>--> 
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/Multirule.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/Multirule.xml
@@ -4,6 +4,7 @@
 <t:property name="account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account4.name" value="test4.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos273-3${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Sieve Mail" />
 
@@ -45,7 +46,7 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
 	<!-- Remember these values for later -->
 	<t:property name="authToken.admin" value="${authToken}"/>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -67,13 +68,27 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	        
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
+
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -87,6 +102,7 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -100,6 +116,7 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -113,6 +130,7 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n="zimbraAdminSieveScriptAfter">${sieve_rule1}</a>
             </CreateAccountRequest>
         </t:request>
@@ -556,7 +574,7 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
 	  </t:test>
 </t:test_case>
 	  
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -583,5 +601,5 @@ replaceheader :newname "X-New-Sieve-Header1" :newvalue "NewVal1" :comparator "i;
 	        </t:response>
 	    </t:test>
 		
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/ReplaceHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-273-EditHeader/ReplaceHeader.xml
@@ -21,6 +21,7 @@
 <t:property name="account19.name" value="test19.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account20.name" value="test20.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account21.name" value="test21.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos273${TIME}${COUNTER}" />
 
 <t:property name="outgoing.name" value="outgoing.${TIME}.${COUNTER}@${defaultdomain.name}" />
 
@@ -62,7 +63,7 @@
 	<!-- Remember these values for later -->
 	<t:property name="authToken.admin" value="${authToken}"/>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -95,13 +96,28 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
+
 	    
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -115,6 +131,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -128,6 +145,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -141,6 +159,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -154,6 +173,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account5.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -169,6 +189,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account6.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -184,6 +205,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account7.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -199,6 +221,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account8.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -214,6 +237,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account9.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -229,6 +253,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account10.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -244,6 +269,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account11.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -259,6 +285,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account12.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -274,6 +301,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account13.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -290,6 +318,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account14.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -306,6 +335,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account15.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -322,6 +352,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account16.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -338,6 +369,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account17.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -354,6 +386,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account18.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -370,6 +403,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account19.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -386,6 +420,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account20.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -402,6 +437,7 @@
     <CreateAccountRequest xmlns="urn:zimbraAdmin">
      <name>${account21.name}</name>
      <password>${defaultpassword.value}</password>
+     <a n="zimbraCOSId">${cosid}</a>
     </CreateAccountRequest>
    </t:request>
    <t:response>
@@ -418,6 +454,7 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${outgoing.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -2904,7 +2941,7 @@
                             	    
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -2942,5 +2979,5 @@
 			</t:response>
 		</t:test>
 		
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-283.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-283.xml
@@ -8,6 +8,8 @@
 <t:property name="test_account6.name" value="test6.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account7.name" value="test7.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="test_account8.name" value="test8.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos283${TIME}${COUNTER}" />
+
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-283/mime01.txt"/>
 
 <t:property name="mail_subject" value="Spam Mail" />
@@ -69,7 +71,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
 </t:test_case>
 
 
-<t:test_case testcaseid="acctSetup1" type="smoke">
+<t:test_case testcaseid="acctSetup1" type="always">
     <t:objective>create test account</t:objective>
     
 	<t:test required="true">
@@ -84,7 +86,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
 		</t:response>
 	</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -106,13 +108,27 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 	        
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -126,6 +142,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule1}</a>
             </CreateAccountRequest>
         </t:request>
@@ -140,6 +157,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account3.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule2}</a>
             </CreateAccountRequest>
         </t:request>
@@ -154,6 +172,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account4.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule3}</a>
             </CreateAccountRequest>
         </t:request>
@@ -168,6 +187,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account5.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule4}</a>
             </CreateAccountRequest>
         </t:request>
@@ -182,6 +202,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account6.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule5}</a>
             </CreateAccountRequest>
         </t:request>
@@ -196,6 +217,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account7.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule6}</a>
             </CreateAccountRequest>
         </t:request>
@@ -210,6 +232,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${test_account8.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cosid}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule7}</a>
             </CreateAccountRequest>
         </t:request>
@@ -721,7 +744,7 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
 		             
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -748,5 +771,5 @@ replaceheader :newname "X-New-Header2" :newvalue "NEWVAL" :matches "X-NEW-HEADER
 	        </t:response>
 	    </t:test>
 
-    </t:finally>    
+    </t:finally>-->  
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-560-NotificationEscape.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-560-NotificationEscape.xml
@@ -10,7 +10,7 @@
 	<t:property name="notify_account4.name" value="notify4.${TIME}.${COUNTER}@${defaultdomain.name}" />
 	<t:property name="test_account5.name" value="test5.${TIME}.${COUNTER}@${defaultdomain.name}" />
 	<t:property name="notify_account5.name" value="notify5.${TIME}.${COUNTER}@${defaultdomain.name}" />	
-
+        <t:property name="cos.name" value="cos560${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
 	<t:property name="mail_subject_1" value="mail_subject"></t:property>
@@ -67,7 +67,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -89,13 +89,27 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	    
+                <t:test id="CreateCosRequest1">
+                    <t:request>
+                        <CreateCosRequest xmlns="urn:zimbraAdmin">
+                            <name xmlns="">${cos.name}</name>
+                            <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                        </CreateCosRequest>
+                    </t:request>
+                    <t:response>
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                    </t:response>
+                </t:test>
+
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule1}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -109,6 +123,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule2}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -122,6 +137,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule3}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -135,6 +151,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account4.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule4}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -148,6 +165,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${test_account5.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraMailSieveScript">${sieve_rule5}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -161,6 +179,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify_account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -173,6 +192,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify_account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -185,6 +205,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify_account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -197,6 +218,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify_account4.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -209,6 +231,7 @@
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${notify_account5.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -563,7 +586,7 @@
 
 	</t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -590,5 +613,5 @@
 	        </t:response>
 	    </t:test>
 
-    </t:finally>						
+    </t:finally>-->						
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-863.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-863.xml
@@ -371,7 +371,7 @@ if string :count "ne" :comparator "i;ascii-numeric" ["${text}","${undefined}"] [
 
     <t:test_case testcaseid="ZCS-863_rule1" type="bhr" bugids="ZCS-863">
         <t:objective>Verify the various combination of parameters with :value and :count for the test "string"</t:objective>
-        <t:test>
+        <!--<t:test>
             <t:request>
                 <ModifyConfigRequest xmlns="urn:zimbraAdmin">
                     <a n="zimbraCustomMimeHeaderNameAllowed">X-Test-Header</a>
@@ -380,7 +380,7 @@ if string :count "ne" :comparator "i;ascii-numeric" ["${text}","${undefined}"] [
             <t:response>
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
-        </t:test>
+        </t:test>-->
 
         <t:test id="modifyaccountrequest1">
             <t:request>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-892.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-892.xml
@@ -14,6 +14,8 @@
 		value="test5_${TIME}${COUNTER}@${defaultdomain.name}" />
 <t:property name="account6.name"
 		value="test6_${TIME}${COUNTER}@${defaultdomain.name}" />
+
+<t:property name="cos.name" value="cos892${TIME}${COUNTER}" />
 		
 <!-- Variables declaration -->
 <t:property name="msg_subject" value="Test Sieve" />
@@ -106,7 +108,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
             </t:response>
      </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -128,13 +130,27 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
 	    	 
+         <t:test id="CreateCosRequest1">
+             <t:request>
+                 <CreateCosRequest xmlns="urn:zimbraAdmin">
+                     <name xmlns="">${cos.name}</name>
+                     <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+             </t:request>
+             <t:response>
+                 <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                 <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+             </t:response>
+         </t:test>
+
 	 <t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -151,6 +167,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -168,6 +185,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -185,6 +203,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -202,6 +221,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account4.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -219,6 +239,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account5.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule5}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -236,6 +257,7 @@ replaceheader :newvalue "NewValue" :count "le" :comparator "i;ascii-numeric" "X-
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account6.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule6}</a>
 				</CreateAccountRequest>
 			</t:request>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-893.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-893.xml
@@ -7,6 +7,7 @@
 <t:property name="account3.name"
 		value="test3_${TIME}${COUNTER}@${defaultdomain.name}" />
 
+<t:property name="cos.name" value="cos893${TIME}${COUNTER}" />
 <!-- Variables declaration -->
 <t:property name="msg01.file" value="${testMailRaw.root}/zcs-893/mime01.txt" />
 <t:property name="msg02.file" value="${testMailRaw.root}/zcs-893/mime02.txt" />
@@ -68,7 +69,7 @@ deleteheader "X-New-Header";
             </t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -90,13 +91,27 @@ deleteheader "X-New-Header";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-		
+	    </t:test>-->
+	
+                <t:test id="CreateCosRequest1">
+                    <t:request>
+                        <CreateCosRequest xmlns="urn:zimbraAdmin">
+                            <name xmlns="">${cos.name}</name>
+                            <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                        </CreateCosRequest>
+                    </t:request>
+                    <t:response>
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                        <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                    </t:response>
+                </t:test>
+	
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -114,6 +129,7 @@ deleteheader "X-New-Header";
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account2.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -131,6 +147,7 @@ deleteheader "X-New-Header";
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account3.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
 				</CreateAccountRequest>
 			</t:request>
@@ -366,7 +383,7 @@ deleteheader "X-New-Header";
 </t:test_case> 
 
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -393,6 +410,6 @@ deleteheader "X-New-Header";
 	        </t:response>
 	    </t:test>
 
-    </t:finally> 
+    </t:finally>-->
     
 </t:tests>


### PR DESCRIPTION
- Used new COS instead of modifying existing COS
- Moved Modify Global config to setup script handled by zm-continouus-integration and commented out modifyconfig test steps
- Fixed issues related to incorrect type used causing account creation to be skipped
- Skipped Custom-Header.xml test file as it would overwrite zimbraCustomMimeHeaderNameAllowed and cause other Sieve tests to fail 