### PR TITLE
ZCS-10176: Fixed Sieve testcases

### DIFF
--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106846.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106846.xml
@@ -2,6 +2,7 @@
     <!-- Test accounts declaration -->
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_notify_account1.name" value="notify1.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos106846${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -43,11 +44,25 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
             </t:response>
         </t:test>
 
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+       </t:test>
+
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
                 </CreateAccountRequest>
             </t:request>
@@ -61,6 +76,7 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${test_notify_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -68,7 +84,7 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -90,7 +106,7 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
     
     </t:test_case>
 
@@ -197,7 +213,7 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
         </t:test>
     </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig </t:objective>
         
         <t:test required="true">
@@ -224,5 +240,5 @@ notify :from "notification_test@${defaultdomain.name}" :message "notify_msg3"
 	        </t:response>
 	    </t:test>
 
-    </t:finally>
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106900.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106900.xml
@@ -60,19 +60,8 @@ notify :message "notification_msg4"
             </t:response>
         </t:test>
 
-        <t:test required="true">
-            <t:request>
-                <CreateAccountRequest xmlns="urn:zimbraAdmin">
-                    <name>${test_account1.name}</name>
-                    <password>${defaultpassword.value}</password>
-                </CreateAccountRequest>
-            </t:request>
-            <t:response>
-                <t:select path="//admin:CreateAccountResponse/admin:account" attr="id" set="test_account1.id" />
-            </t:response>
-        </t:test>
 
-	    <t:test>
+            <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -84,7 +73,7 @@ notify :message "notification_msg4"
 	        </t:response>
 	    </t:test>
 	
-	    <!--<t:test>
+	    <t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cosid}</id>
@@ -107,8 +96,21 @@ notify :message "notification_msg4"
             <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
             <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
         </t:response>
-       </t:test>
-	    
+       </t:test>	    
+
+        <t:test required="true">
+            <t:request>
+                <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                    <name>${test_account1.name}</name>
+                    <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
+                </CreateAccountRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateAccountResponse/admin:account" attr="id" set="test_account1.id" />
+            </t:response>
+        </t:test>
+
         <t:test required="true">
             <t:request>
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1287.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1287.xml
@@ -121,7 +121,7 @@
                     <t:request>
                         <CreateCosRequest xmlns="urn:zimbraAdmin">
                             <name xmlns="">${cos.name}</name>
-                            <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                            <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
                         </CreateCosRequest>
                 </t:request>
                 <t:response>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1378-ResetVarsBetweenFilters.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1378-ResetVarsBetweenFilters.xml
@@ -85,7 +85,7 @@ if  header :matches ["X-Header3"] "*" {
         </t:test>
     </t:test_case>
 
-    <t:test_case testcaseid="configSetup" type="always">
+    <!--<t:test_case testcaseid="configSetup" type="always">
         <t:test required="true">
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAdmin">
@@ -112,7 +112,7 @@ if  header :matches ["X-Header3"] "*" {
                 <t:select path="//admin:ModifyConfigResponse" />
             </t:response>
         </t:test>
-    </t:test_case>
+    </t:test_case>-->
 
     <t:test_case testcaseid="zcs-1378_rule1" type="bhr" bugids="zcs-1378">
         <t:objective>


### PR DESCRIPTION
Performed below fixes:
- ZCS-1378-ResetVarsBetweenFilters test - was unsetting zimbraCustomMimeHeaderNameAllowed causing subsequent tests using zimbraCustomMimeHeaderNameAllowed values to fail. Commented mcf test as it is handled during installation.
- Did fixes in other tests related to incorrect Sieve attribute set at cos