### PR TITLE
added tests which are failing due to existing bug

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -158,3 +158,43 @@ build/temp/data/soapvalidator/Admin/Server/Server.xml
 
 # Include below test once flushcache is implemented using kubectl
 build/temp/data/soapvalidator/Search/DelayedIndexing/ZCS-8516.xml
+
+# Below Tests are failing due to different existing bugs or feature depricated.
+build/temp/data/soapvalidator/Admin/Bugs/Bug25398.xml
+build/temp/data/soapvalidator/Admin/Bugs/Bug74981.xml
+build/temp/data/soapvalidator/Admin/ExternalSharing/ExternalVirualAccountPolicy.xml
+build/temp/data/soapvalidator/Admin/ExternalSharing/ExternalVirualAccountWhiteList.xml
+build/temp/data/soapvalidator/Admin/General/GenCSRRequest.xml
+build/temp/data/soapvalidator/Admin/General/GetCSRRequest.xml
+build/temp/data/soapvalidator/Admin/General/GetCertRequest.xml
+build/temp/data/soapvalidator/Admin/General/SpellCheck.xml
+build/temp/data/soapvalidator/Admin/General/ReindexRequest-Basic.xml
+build/temp/data/soapvalidator/Admin/MailQueue/GetMailQueueInfoRequest.xml
+build/temp/data/soapvalidator/Admin/MailQueue/GetMailQueueRequest.xml
+build/temp/data/soapvalidator/Admin/MailQueue/MailQueueFlushRequest.xml
+build/temp/data/soapvalidator/Admin/Resource/Resource-Create.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetAggregateQuotaUsageOnServerRequest.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetMailQueueInfoRequest.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetMailQueueRequest.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetServiceStatusRequest.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/MailQueueActionRequest.xml
+build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/MailQueueFlushRequest.xml
+build/temp/data/soapvalidator/Admin/Server/Server-GetNifs.xml
+build/temp/data/soapvalidator/Admin/Zimlets/ACLZimlets.xml
+build/temp/data/soapvalidator/Admin/Zimlets/ModifyZimletPrefsRequest-Basic.xml
+build/temp/data/soapvalidator/Admin/Zimlets/NewCosZimlets.xml
+build/temp/data/soapvalidator/Admin/Zimlets/OotbZimlets.xml
+build/temp/data/soapvalidator/Admin/Zimlets/ZimletRequest.xml
+build/temp/data/soapvalidator/Calendar/Bugs/Bug42129.xml
+build/temp/data/soapvalidator/Calendar/Bugs/Bug62417.xml
+build/temp/data/soapvalidator/General/GetInfoRequest.xml
+build/temp/data/soapvalidator/General/SpellCheck.xml
+build/temp/data/soapvalidator/General/SpellCheckAddWord.xml
+build/temp/data/soapvalidator/General/VersionInfo.xml
+build/temp/data/soapvalidator/General/ZimbraMessageIdDedupeCacheTimeout.xml
+build/temp/data/soapvalidator/Search/Bugs/SortBy-ZCS-3705.xml
+build/temp/data/soapvalidator/Search/Contacts/Search-Contact-Lucene.xml
+build/temp/data/soapvalidator/Search/Search.Browseby.xml
+build/temp/data/soapvalidator/Tasks/Get-Tasks.xml
+build/temp/data/soapvalidator/Briefcase/Bugs/Bug44557.xml
+build/temp/data/soapvalidator/Briefcase/Bugs/Bug92427.xml


### PR DESCRIPTION

build/temp/data/soapvalidator/Admin/Bugs/Bug25398.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-7258
-- | -- | --
build/temp/data/soapvalidator/Admin/Bugs/Bug74981.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/ExternalSharing/ExternalVirualAccountPolicy.xml | Script issue | Need to put dealy   after FolderActionRequest in "zimbraExternalSharingEnabled04"
build/temp/data/soapvalidator/Admin/ExternalSharing/ExternalVirualAccountWhiteList.xml | Script issue | Need to put dealy   after FolderActionRequest in   "zimbraExternalShareDomainWhitelistEnabled04"
build/temp/data/soapvalidator/Admin/General/GenCSRRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/General/GetCSRRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/General/GetCertRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/General/SpellCheck.xml | Depricated |  
build/temp/data/soapvalidator/Admin/General/ReindexRequest-Basic.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-7286
build/temp/data/soapvalidator/Admin/MailQueue/GetMailQueueInfoRequest.xml | Script issue | invalid request: server with name zmc-mta could not be found    need to set mta-server
build/temp/data/soapvalidator/Admin/MailQueue/GetMailQueueRequest.xml | Script issue | invalid request: server with name zmc-mta could not be found    need to set mta-server
build/temp/data/soapvalidator/Admin/MailQueue/MailQueueFlushRequest.xml | Script issue | invalid request: server with name zmc-mta could not be found    need to set mta-server
build/temp/data/soapvalidator/Admin/Resource/Resource-Create.xml |   |  
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetAggregateQuotaUsageOnServerRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetMailQueueInfoRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetMailQueueRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/GetServiceStatusRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/MailQueueActionRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Rights/AuthToken/AdminToken/MailQueueFlushRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Server/Server-GetNifs.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-5619
build/temp/data/soapvalidator/Admin/Zimlets/ACLZimlets.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6278
build/temp/data/soapvalidator/Admin/Zimlets/ModifyZimletPrefsRequest-Basic.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6278
build/temp/data/soapvalidator/Admin/Zimlets/NewCosZimlets.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6278
build/temp/data/soapvalidator/Admin/Zimlets/OotbZimlets.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6278
build/temp/data/soapvalidator/Admin/Zimlets/ZimletRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6278
build/temp/data/soapvalidator/Calendar/Bugs/Bug42129.xml | Script issue | Delay issue between   several requets
build/temp/data/soapvalidator/Calendar/Bugs/Bug62417.xml | Script issue | CreateGalSyncAccountRequest   xmlns="urn:zimbraAdmin" name="name${TIME}${COUNTER}"   type="zimbra" domain="${domain1.name}">   Remove "server   name="zimbraServer.name"
build/temp/data/soapvalidator/General/GetInfoRequest.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-9497
build/temp/data/soapvalidator/General/SpellCheck.xml | Depricated |  
build/temp/data/soapvalidator/General/SpellCheckAddWord.xml | Depricated |  
build/temp/data/soapvalidator/General/VersionInfo.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-9497
build/temp/data/soapvalidator/General/ZimbraMessageIdDedupeCacheTimeout.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-6131
build/temp/data/soapvalidator/Search/Bugs/SortBy-ZCS-3705.xml | Script Issue | invalid request: specified zimbraMailHost does not correspond to a   mailclient server with service webapp enabled: zmc-proxy
build/temp/data/soapvalidator/Search/Contacts/Search-Contact-Lucene.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-8108
build/temp/data/soapvalidator/Search/Search.Browseby.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-7915
build/temp/data/soapvalidator/Tasks/Get-Tasks.xml | Script Issue | GetMsgResponse : Timezone issue Append 'Z"
build/temp/data/soapvalidator/Briefcase/Bugs/Bug44557.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-8196    ...https://jira.corp.synacor.com/browse/ZCS-9083
build/temp/data/soapvalidator/Briefcase/Bugs/Bug92427.xml | Existing bug | https://jira.corp.synacor.com/browse/ZCS-8196

