### PR TITLE
Added test for Zimbra to zimbra account migration:ZCS9805

### DIFF
--- a/data/soapvalidator/Admin/Accounts/account_migration.xml
+++ b/data/soapvalidator/Admin/Accounts/account_migration.xml
@@ -86,7 +86,8 @@
             </FetchAllRemoteAccountsRequest>
          </t:request>
          <t:response>
-            <t:select path="//admin:FetchAllRemoteAccountsResponse"/>
+		 <t:select path="//admin:FetchAllRemoteAccountsResponse"/>
+		 <t:select path="//admin:FetchAllRemoteAccountsResponse/admin:account" attr="name" match="${sourceUser}"/>
         </t:response>
     </t:test>
 </t:test_case>

--- a/data/soapvalidator/Admin/Accounts/account_migration.xml
+++ b/data/soapvalidator/Admin/Accounts/account_migration.xml
@@ -1,0 +1,151 @@
+<t:tests xmlns:t="urn:zimbraTestHarness">
+
+<t:property name="test_account1.name" value="test.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+<t:property name="test_account1.password" value="${defaultpassword.value}"/>
+<t:property name="domain1.name" value="domain${TIME}${COUNTER}"/>
+<t:property name="subject1.valid" value="Your email migration is done!"/>
+<t:property name="sourceHost" value="apps-development.synacor.tk"/>
+<t:property name="sourceAdminUserName" value="admin@apps-development.synacor.tk"/>
+<t:property name="sourceAdminUserPassword" value="${defaultpassword.value}"/> 
+<t:property name="sourceUser" value="source_user@apps-development.synacor.tk"/>
+
+<t:test_case testcaseid="Ping" type="always" >
+    <t:objective>basic system check</t:objective>
+
+    <t:test required="true">
+        <t:request>
+            <PingRequest xmlns="urn:zimbraAdmin"/>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:PingResponse"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+
+<t:test_case testcaseid="admin_auth_account_create" type="always" >
+    <t:objective>login as the admin</t:objective>
+
+    <t:test required="true" >
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+                <name>${admin.user}</name>
+                <password>${admin.password}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+
+<t:test_case testcaseid="CreateAccountRequest1" type="smoke" bugids="9805">
+    <t:objective>Create an account with valid values.</t:objective>
+
+    <t:test >
+        <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                <name>${test_account1.name}</name>
+                <password>${defaultpassword.value}</password>
+            </CreateAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="name"  set="account.name"/>
+        </t:response>
+    </t:test>  
+
+</t:test_case>
+
+<t:test_case testcaseid="ValidateRemoteZimbraConnectionRequest" type="smoke" bugids="9805">
+    <t:objective>ValidateRemoteZimbraConnection API will connect to source host and validate the admin credentials..</t:objective>
+
+    <t:test >
+        <t:request>
+            <ValidateRemoteZimbraConnectionRequest xmlns="urn:zimbraAdmin">
+                <sourceHost>${sourceHost}</sourceHost>
+                <sourceAdminUserName>${sourceAdminUserName}</sourceAdminUserName>
+		<sourceAdminUserPassword>${sourceAdminUserPassword}</sourceAdminUserPassword>
+            </ValidateRemoteZimbraConnectionRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:ValidateRemoteZimbraConnectionResponse"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+<t:test_case testcaseid="FetchAllRemoteAccountsRequest" type="smoke">
+    <t:objective>Fetch all the users from the source zimbra system based on the domain name.</t:objective>
+    <t:test >
+        <t:request>
+            <FetchAllRemoteAccountsRequest xmlns="urn:zimbraAdmin">
+                <domain by="name">${sourceHost}</domain>
+            </FetchAllRemoteAccountsRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:FetchAllRemoteAccountsResponse"/>
+        </t:response>
+    </t:test>
+</t:test_case>
+
+
+<t:test_case testcaseid="ValidateMigrateUsersDataRequest" type="smoke">
+    <t:objective>MigrateUsersData.</t:objective>
+    <t:test >
+        <t:request>
+            <MigrateUsersDataRequest xmlns="urn:zimbraAdmin">
+		<isSsl>true</isSsl>
+		<isSslVerify>false</isSslVerify>
+		<migrate>
+		<sourceUser>${sourceUser}</sourceUser>
+		<targetUser>${account.name}</targetUser>
+		<typeOfData>imap,caldav,contact</typeOfData>
+	        </migrate>
+            </MigrateUsersDataRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:MigrateUsersDataResponse"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+<t:delay sec="30"/>
+<t:test_case testcaseid="Authentication by target user" type="smoke">
+    <t:objective>Login with Target user</t:objective>
+
+    <t:test required="true">
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+                <account by="name">${account.name}</account>
+                <password>${defaultpassword.value}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//acct:AuthResponse/acct:lifetime" match="^\d+$"/>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+<t:test_case testcaseid="Vailidate data Migration compeletion" type="smoke">
+    <t:objective>Vailidate data Migration compeletion.</t:objective>
+
+    <t:test >
+           <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="message">
+                <query>subject: (${subject1.valid})</query>
+            </SearchRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//mail:SearchResponse/mail:m/mail:su" match="^${subject1.valid}$"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+</t:tests>


### PR DESCRIPTION
Added test for Zimbra to zimbra account migration:ZCS9805:

-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

AuthRequest                                         151          2             75
CreateAccountRequest                                223          1            223
SearchRequest                                       256          1            256
PingRequest                                         375          1            375
FetchAllRemoteAccountsRequest                      4845          1           4845
ValidateRemoteZimbraConnectionRequest                88          1             88
MigrateUsersDataRequest                              57          1             57


-------------------SUMMARY---------------------

PASS 0001   1/1   375ms PingRequest                     Ping
PASS 0002   1/1    92ms AuthRequest                     admin_auth_account_create
PASS 0003   1/1   223ms CreateAccountRequest            CreateAccountRequest1 (Fixed Bug: #9805)
PASS 0004   1/1    88ms ValidateRemoteZimbraConnectionRequest   ValidateRemoteZimbraConnectionRequest (Fixed Bug: #9805)
PASS 0005   1/1  4845ms FetchAllRemoteAccountsRequest   FetchAllRemoteAccountsRequest
PASS 0006   1/1    57ms MigrateUsersDataRequest         ValidateMigrateUsersDataRequest
PASS 0007   2/2    59ms AuthRequest                     Authentication by target user
PASS 0008   1/1   256ms SearchRequest                   Vailidate data Migration compeletion


script_parsable:        6       0



TEST CASE Results: 6(PASS) - 0(Fail)


REQUEST/RESPONSE Results: 8(PASS) - 0(Fail)
