### PR TITLE
ZCS-10350: Fixed Sieve test script issues, skipped known issues

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -198,3 +198,14 @@ build/temp/data/soapvalidator/Search/Search.Browseby.xml
 build/temp/data/soapvalidator/Tasks/Get-Tasks.xml
 build/temp/data/soapvalidator/Briefcase/Bugs/Bug44557.xml
 build/temp/data/soapvalidator/Briefcase/Bugs/Bug92427.xml
+
+# Filter and Sieve tests
+# Below tests failing due to Bug# ZCS-10036
+build/temp/data/soapvalidator/Prefs/Filters/ApplyFilterRules/ApplyFilterRulesRequest.xml
+build/temp/data/soapvalidator/Prefs/Filters/Bugs/Bug44588.xml
+# Below test failing due to Bug# ZCS-10057 
+build/temp/data/soapvalidator/Prefs/Filters/Priority/ConversationTest.xml
+# In below test, ModifyFilterRules are performed on domain/cos/server. Will need flushcache for updating ldap values on all mailbox pods.
+build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-500.xml
+# Below tests failing due to Bug# ZCS-10352
+build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-559-EscapeSeq.xml

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1286-SoapToSieve.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1286-SoapToSieve.xml
@@ -369,6 +369,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -726,6 +728,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -905,6 +909,8 @@
 					set="Sent_message6.id" />
 			</t:response>
 		</t:test>
+
+                <t:delay sec="10" />
 
 		<t:test required="true">
 			<t:request>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1390-SoapToSieve.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1390-SoapToSieve.xml
@@ -217,6 +217,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -407,6 +409,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -556,6 +560,8 @@
 					set="Sent_message03.id" />
 			</t:response>
 		</t:test>
+
+                <t:delay sec="10" />
 
 		<t:test required="true">
 			<t:request>
@@ -710,6 +716,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">
@@ -859,6 +867,8 @@
 					set="Sent_message05.id" />
 			</t:response>
 		</t:test>
+
+                <t:delay sec="10" />
 
 		<t:test required="true">
 			<t:request>
@@ -1169,6 +1179,8 @@
 					set="Sent_message06.id" />
 			</t:response>
 		</t:test>
+
+                <t:delay sec="10" />
 
 		<t:test required="true">
 			<t:request>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-375-SoapToSieve.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-375-SoapToSieve.xml
@@ -1390,6 +1390,8 @@
 			</t:response>
 		</t:test>
 
+                <t:delay sec="10" />
+
 		<t:test required="true">
 			<t:request>
 				<AuthRequest xmlns="urn:zimbraAccount">

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-840.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-840.xml
@@ -2,6 +2,7 @@
 
 <t:property name="account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
 <t:property name="account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
+<t:property name="cos.name" value="cos840${TIME}${COUNTER}" />
 
 <t:property name="mail_subject" value="Test Mail" />
 <t:property name="dollar" value="$"/>
@@ -81,7 +82,7 @@ replaceheader :newvalue "Replaced" :matches "${dollar}{headerName}" "*";
         </t:response>
     </t:test>
 
-	    <t:test>
+	   <!-- <t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -103,13 +104,27 @@ replaceheader :newvalue "Replaced" :matches "${dollar}{headerName}" "*";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cos.id" />
+        </t:response>
+    </t:test>
 	        
     <t:test required="true">
         <t:request>
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account1.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>
@@ -122,6 +137,7 @@ replaceheader :newvalue "Replaced" :matches "${dollar}{headerName}" "*";
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account2.name}</name>
                 <password>${defaultpassword.value}</password>
+                <a n="zimbraCOSId">${cos.id}</a>
                 <a n = "zimbraAdminSieveScriptAfter">${sieve_rule1}</a>
             </CreateAccountRequest>
         </t:request>
@@ -220,17 +236,14 @@ replaceheader :newvalue "Replaced" :matches "${dollar}{headerName}" "*";
             </t:response>
         </t:test>
 
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
-	                <a n="zimbraSieveEditHeaderEnabled">FALSE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>
+        <t:test>
+            <t:request>
+                <DeleteCosRequest xmlns="urn:zimbraAdmin">
+                    <id>${cos.id}</id>
+                </DeleteCosRequest>
+            </t:request>
+        </t:test>
 
-    </t:finally> 
+    </t:finally>
+
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-842.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-842.xml
@@ -22,6 +22,7 @@
 		value="reciever9${TIME}${COUNTER}@${defaultdomain.name}" />
 	<t:property name="reciever_account10.name"
 		value="reciever10${TIME}${COUNTER}@${defaultdomain.name}" />
+        <t:property name="cos.name" value="cos842${TIME}${COUNTER}" />
 	
 	<t:property name="subject" value="sample abc test 123 test ABC test" />
 	<t:property name="0" value="$\{0}" />
@@ -130,7 +131,7 @@ tag "${1}";
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -152,13 +153,27 @@ tag "${1}";
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+            <t:test id="CreateCosRequest1">
+                <t:request>
+                    <CreateCosRequest xmlns="urn:zimbraAdmin">
+                        <name xmlns="">${cos.name}</name>
+                        <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                    </CreateCosRequest>
+                </t:request>
+                <t:response>
+                    <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                    <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+                </t:response>
+            </t:test>
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${sender_account.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -178,6 +193,7 @@ tag "${1}";
 					<name>${reciever_account1.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test1}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -197,6 +213,7 @@ tag "${1}";
 					<name>${reciever_account2.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test2}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -216,6 +233,7 @@ tag "${1}";
 					<name>${reciever_account3.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test3}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -235,6 +253,7 @@ tag "${1}";
 					<name>${reciever_account4.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test4}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -254,6 +273,7 @@ tag "${1}";
 					<name>${reciever_account5.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test5}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -273,6 +293,7 @@ tag "${1}";
 					<name>${reciever_account6.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test6}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -292,6 +313,7 @@ tag "${1}";
 					<name>${reciever_account7.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test7}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -311,6 +333,7 @@ tag "${1}";
 					<name>${reciever_account8.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptAfter">${sieve_test8}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -330,6 +353,7 @@ tag "${1}";
 					<name>${reciever_account9.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptAfter">${sieve_test9}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -349,6 +373,7 @@ tag "${1}";
 					<name>${reciever_account10.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraMailSieveScript">${sieve_test10}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -1115,17 +1140,13 @@ tag "${1}";
             </t:response>
         </t:test>
 
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
-	                <a n="zimbraSieveEditHeaderEnabled">FALSE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>
+        <t:test>
+            <t:request>
+                <DeleteCosRequest xmlns="urn:zimbraAdmin">
+                    <id>${cosid}</id>
+            </DeleteCosRequest>
+            </t:request>
+        </t:test>
+    </t:finally>
 
-    </t:finally>	
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-865.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-865.xml
@@ -56,6 +56,7 @@
 <t:property name="account25.name"
 		value="test25_${TIME}${COUNTER}@${defaultdomain.name}" />
 <t:property name="msg.subject2" value="1" />
+<t:property name="cos.name" value="cos865${TIME}${COUNTER}" />
 
 	<t:property name="sieve_rule1"
 		value='require  ["editheader", "relational"];
@@ -314,7 +315,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
             </t:response>
         </t:test>
 
-		<t:test>
+		<!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -336,13 +337,28 @@ require ["editheader", "comparator-i;ascii-numeric"];
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -360,6 +376,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -377,6 +394,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account2.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -394,6 +412,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account3.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -411,6 +430,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account4.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule4}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -428,6 +448,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account5.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule5}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -445,6 +466,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account6.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule6}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -462,6 +484,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account7.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule7}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -479,6 +502,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account8.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule8}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -496,6 +520,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account9.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule9}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -513,6 +538,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account10.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule10}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -530,6 +556,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account11.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule11}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -547,6 +574,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account12.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule12}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -564,6 +592,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account13.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule13}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -581,6 +610,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account14.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule14}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -598,6 +628,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account15.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule15}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -615,6 +646,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account16.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule16}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -632,6 +664,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account17.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule17}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -649,6 +682,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account18.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule18}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -666,6 +700,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account19.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule19}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -683,6 +718,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account20.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule20}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -700,6 +736,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account21.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule21}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -717,6 +754,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account22.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule22}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -734,6 +772,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account23.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule23}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -751,6 +790,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account24.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule24}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -768,6 +808,7 @@ require ["editheader", "comparator-i;ascii-numeric"];
 					<name>${account25.name}</name>
 					<password>${defaultpassword.value}</password>
 					<a n="zimbraAdminSieveScriptBefore">${sieve_rule25}</a>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>
@@ -3137,17 +3178,14 @@ require ["editheader", "comparator-i;ascii-numeric"];
             </t:response>
         </t:test>
 
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
-	                <a n="zimbraSieveEditHeaderEnabled">FALSE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>
+        <t:test>
+            <t:request>
+                <DeleteCosRequest xmlns="urn:zimbraAdmin">
+                    <id>${cosid}</id>
+                </DeleteCosRequest>
+            </t:request>
+        </t:test>
 
     </t:finally>
+
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-870-NotificationReturnPathEscape.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-870-NotificationReturnPathEscape.xml
@@ -10,6 +10,7 @@
     <t:property name="notify_account7.name" value="notify7.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="notify_account8.name" value="notify8.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="notify_account9.name" value="notify9.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos870${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="mail_subject" value="mail_subject.${COUNTER}"></t:property>
@@ -99,7 +100,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -121,7 +122,20 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveNotifyActionRFCCompliant">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    
         <t:test required="true">
             <t:request>
@@ -129,6 +143,7 @@
                     <name>${test_account.name}</name>
                     <password>${defaultpassword.value}</password>
                     <a n="zimbraMailSieveScript">${sieve_rule1}</a>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -141,6 +156,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account1.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -153,6 +169,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account2.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -165,6 +182,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account3.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -177,6 +195,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account4.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -189,6 +208,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account5.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -201,6 +221,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account6.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -213,6 +234,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account7.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -225,6 +247,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account8.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -237,6 +260,7 @@
                 <CreateAccountRequest xmlns="urn:zimbraAdmin">
                     <name>${notify_account9.name}</name>
                     <password>${defaultpassword.value}</password>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -1003,17 +1027,14 @@
         </t:response>
     </t:test>
 
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
-	                <a n="zimbraSieveNotifyActionRFCCompliant">FALSE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>        
+    <t:test>
+        <t:request>
+	    <DeleteCosRequest xmlns="urn:zimbraAdmin">
+	        <id>${cosid}</id>
+	    </DeleteCosRequest>
+	</t:request>
+    </t:test>        
 
-</t:finally>
+  </t:finally>
+
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-880.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-880.xml
@@ -3,6 +3,7 @@
     <t:property name="test_account1.name" value="test1.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account2.name" value="test2.${TIME}.${COUNTER}@${defaultdomain.name}" />
     <t:property name="test_account3.name" value="test3.${TIME}.${COUNTER}@${defaultdomain.name}" />
+    <t:property name="cos.name" value="cos880${TIME}${COUNTER}" />
 
     <!-- Variables declaration -->
     <t:property name="folder_inbox" value="Inbox" />
@@ -51,7 +52,7 @@
             </t:response>
         </t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -73,7 +74,20 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+        <t:test id="CreateCosRequest1">
+            <t:request>
+                <CreateCosRequest xmlns="urn:zimbraAdmin">
+                    <name xmlns="">${cos.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+                </CreateCosRequest>
+            </t:request>
+            <t:response>
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+                <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+            </t:response>
+        </t:test>
 	    
         <t:test required="true">
             <t:request>
@@ -81,6 +95,7 @@
                     <name>${test_account1.name}</name>
                     <password>${defaultpassword.value}</password>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule1}</a>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -95,6 +110,7 @@
                     <name>${test_account2.name}</name>
                     <password>${defaultpassword.value}</password>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule2}</a>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -109,6 +125,7 @@
                     <name>${test_account3.name}</name>
                     <password>${defaultpassword.value}</password>
                     <a n="zimbraAdminSieveScriptBefore">${sieve_rule3}</a>
+                    <a n="zimbraCOSId">${cosid}</a>
                 </CreateAccountRequest>
             </t:request>
             <t:response>
@@ -317,17 +334,14 @@
             </t:response>
         </t:test>
 
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cosid}</id>
-	                <a n="zimbraSieveEditHeaderEnabled">FALSE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>
+        <t:test>
+            <t:request>
+                <DeleteCosRequest xmlns="urn:zimbraAdmin">
+                    <id>${cosid}</id>
+                </DeleteCosRequest>
+            </t:request>
+        </t:test>
 
-    </t:finally>                
+    </t:finally>
+             
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-887-Immutable.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-887-Immutable.xml
@@ -245,7 +245,7 @@
 			</t:response>
 		</t:test>
 		
-	    <t:test>
+	    <!--<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cos1.id}</id>
@@ -255,7 +255,19 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+            <t:test>
+                <t:request>
+                    <ModifyAccountRequest xmlns="urn:zimbraAdmin">
+                        <id>${test_account3.id}</id>
+                        <a n="zimbraSieveImmutableHeaders">Received,DKIM-Signature,Authentication-Results,Received-SPF,Message-ID,Content-Type,Content-Disposition,Content-Transfer-Encoding,MIME-Version</a>
+                    </ModifyAccountRequest>
+                </t:request>
+                <t:response>
+                    <t:select path="//admin:ModifyAccountResponse/admin:account"/>            
+                </t:response>
+            </t:test>
 	    
     <t:test >
         <t:request>


### PR DESCRIPTION
Fixed below Sieve scripts:

> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1286-SoapToSieve.xml - Fixed by adding delay after SendMsgRequest. Fixed 2 cases.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1390-SoapToSieve.xml - Fixed by adding delay after SendMsgRequest. Fixed 5 cases.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-375-SoapToSieve.xml - Fixed by adding delay after SendMsgRequest. Fixed 1 case.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-500.xml - Skipped this test. ModifyFilterRules are performed on domain/cos/server. Will not modify ldap cache for accounts on non-admin mailbox pod.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-559-EscapeSeq.xml - Reported ZCS-10352 and skipped test
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-840.xml - Fixed by setting sieve attribute for new cos and using that cos.	Fixed 1 case.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-842.xml - Fixed by setting sieve attribute for new cos and using that cos.	Fixed 1 case.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-865.xml - Fixed by setting sieve attribute for new cos and using that cos.	Fixed 1 case.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-870-NotificationReturnPathEscape.xml - Fixed by setting sieve attribute for new cos and using that cos.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-880.xml - Fixed by setting sieve attribute for new cos and using that cos. Fixed 1 case.
> 
> build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-887-Immutable.xml - Fixed by setting zimbraSieveImmutableHeaders attribute at account level. Fixed 1 case.