### PR TITLE
Added soap automation for ResetAccountPasswordRequest API

### DIFF
--- a/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
@@ -126,7 +126,8 @@
          <t:response>
             <t:select path="//mail:GetMsgResponse/mail:m" attr="id" match="${msg.id}" />
             <t:select path="//mail:GetMsgResponse/mail:m/mail:mp" attr="ct" match="multipart/alternative" />
-	   <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
+	    <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
+	    <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Kindly click on the link to set your password and start using Zimbra Cloud : https://zmc-mailbox:8443/service/extuserprov/?p"/>
          </t:response>
       </t:test>
    </t:test_case>

--- a/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
@@ -32,7 +32,7 @@
             </CreateAccountRequest>
          </t:request>
          <t:response>
-            <t:select path="//admin:CreateAccountResponse/admin:account" attr="name" set="account.name" />
+            <t:select path="//admin:CreateAccountResponse/admin:account"/>
          </t:response>
       </t:test>
       <t:test id="create_testAccount2" required="true">
@@ -41,13 +41,12 @@
                <name>${account1.name}</name>
                <password>${account1.password}</password>
                <a n="zimbraFeatureResetPasswordStatus">enabled</a>
-               <a n="zimbraPrefPasswordRecoveryAddress">${account.name}</a>
+               <a n="zimbraPrefPasswordRecoveryAddress">${test_account1.name}</a>
                <a n="zimbraPrefPasswordRecoveryAddressStatus">verified</a>
             </CreateAccountRequest>
          </t:request>
          <t:response>
-            <t:select path="//admin:CreateAccountResponse/admin:account" attr="name" set="resetaccount.name" />
-            <t:select path="//admin:CreateAccountResponse/admin:account/admin:a[@n=&quot;zimbraMailHost&quot;]" set="account1.server" />
+            <t:select path="//admin:CreateAccountResponse/admin:account"/>
          </t:response>
       </t:test>
    </t:test_case>
@@ -56,10 +55,13 @@
       <t:objective>Reset password  from recover link</t:objective>
       <t:steps>1. Auth request for admin
                         2. Send RecoverAccountRequest
-                        3. Send ResetAccountPasswordReques
-                        4. Auth with test accout 
-                        5. Search for Reset password email.
-                        4. Validate contents of the email.
+			3. Auth with test accout
+			4. Search for Reset password email.
+			5. Validate contents of the email
+                        6. Send ResetAccountPasswordReques
+                        7. Auth with test accout 
+                        8. Search for Reset password email.
+                        9. Validate contents of the email.
       </t:steps>
 
       <t:test id="auth_admin_account" required="true">
@@ -77,18 +79,65 @@
          <t:request>
             <RecoverAccountRequest xmlns="urn:zimbraMail">
                <op>sendRecoveryLink</op>
-               <email>${resetaccount.name}</email>
+               <email>${account1.name}</email>
             </RecoverAccountRequest>
          </t:request>
          <t:response>
             <t:select path="//RecoverAccountResponse" />
          </t:response>
       </t:test>
+      <t:test id="auth_testAccount1" required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+               <account by="name">${test_account1.name}</account>
+               <password>${defaultpassword.value}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+      <t:test id="Search for Welcome to Zimbra Cloud email">
+         <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="message">
+               <query>subject: (${Subject_cloud})</query>
+            </SearchRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//mail:SearchResponse/mail:m/mail:su" match="^${Subject_cloud}$" />
+            <t:select path="//mail:SearchResponse/mail:m" attr="id" set="msg.id" />
+         </t:response>
+      </t:test>
+      <t:test id="Get Welcome to Zimbra Cloud message and validate contents">
+         <t:request>
+            <GetMsgRequest xmlns="urn:zimbraMail">
+               <m id="${msg.id}" />
+            </GetMsgRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//mail:GetMsgResponse/mail:m" attr="id" match="${msg.id}" />
+            <t:select path="//mail:GetMsgResponse/mail:m/mail:mp" attr="ct" match="multipart/alternative" />
+           <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
+           <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Kindly click on the link to set your password and start using Zimbra Cloud : https://zmc-mailbox:8443/service/extuserprov/?p"/>
+         </t:response>
+      </t:test>
+      <t:test id="auth_admin_account" required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+               <name>${admin.user}</name>
+               <password>${admin.password}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+
       <!-- Reset the password for account 1 user -->
       <t:test id="Send ResetAccountPasswordRequest">
          <t:request>
             <ResetAccountPasswordRequest xmlns="urn:zimbraAdmin">
-               <account by="name">${resetaccount.name}</account>
+               <account by="name">${account1.name}</account>
             </ResetAccountPasswordRequest>
          </t:request>
          <t:response>
@@ -126,8 +175,8 @@
          <t:response>
             <t:select path="//mail:GetMsgResponse/mail:m" attr="id" match="${msg.id}" />
             <t:select path="//mail:GetMsgResponse/mail:m/mail:mp" attr="ct" match="multipart/alternative" />
-	    <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
-	    <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Kindly click on the link to set your password and start using Zimbra Cloud : https://zmc-mailbox:8443/service/extuserprov/?p"/>
+	   <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
+	   <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Kindly click on the link to set your password and start using Zimbra Cloud : https://zmc-mailbox:8443/service/extuserprov/?p"/>
          </t:response>
       </t:test>
    </t:test_case>

--- a/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
@@ -53,28 +53,30 @@
 
    <t:test_case testcaseid="Reset_Account_Password_Valid" type="smoke" bugids="ZCS-10146">
       <t:objective>Reset password  from recover link</t:objective>
-      <t:steps>1. Auth request for admin
+      <t:steps>1. Auth request for account
                         2. Send RecoverAccountRequest
 			3. Auth with test accout
 			4. Search for Reset password email.
 			5. Validate contents of the email
-                        6. Send ResetAccountPasswordReques
+                        6. Auth with Admin and Send ResetAccountPasswordReques
                         7. Auth with test accout 
                         8. Search for Reset password email.
                         9. Validate contents of the email.
       </t:steps>
 
-      <t:test id="auth_admin_account" required="true">
+      <t:test id="auth_account1_account">
          <t:request>
-            <AuthRequest xmlns="urn:zimbraAdmin">
-               <name>${admin.user}</name>
-               <password>${admin.password}</password>
+            <AuthRequest xmlns="urn:zimbraAccount">
+                <account by="name">${account1.name}</account>
+		<password>${account1.password}</password>
             </AuthRequest>
          </t:request>
          <t:response>
-            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
          </t:response>
       </t:test>
+    <!--<prefs/>-->
+
       <t:test id="Send RecoverAccountRequest">
          <t:request>
             <RecoverAccountRequest xmlns="urn:zimbraMail">
@@ -121,7 +123,7 @@
            <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Kindly click on the link to set your password and start using Zimbra Cloud : https://zmc-mailbox:8443/service/extuserprov/?p"/>
          </t:response>
       </t:test>
-      <t:test id="auth_admin_account" required="true">
+       <t:test id="auth_admin_account" required="true">
          <t:request>
             <AuthRequest xmlns="urn:zimbraAdmin">
                <name>${admin.user}</name>

--- a/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ResetAccountPassword.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:tests xmlns:t="urn:zimbraTestHarness">
+   <t:property name="account1.name" value="test1${TIME}@${defaultdomain.name}" />
+   <t:property name="account1.password" value="${defaultpassword.value}" />
+   <t:property name="test_account1.name" value="test.${TIME}.${COUNTER}@${defaultdomain.name}" />
+   <t:property name="test_account1.password" value="${defaultpassword.value}" />
+   <t:property name="Subject_cloud" value="Welcome to Zimbra Cloud" />
+
+   <t:test_case testcaseid="Ping" type="always">
+      <t:objective>Basic system check</t:objective>
+   </t:test_case>
+   <t:test_case testcaseid="Account_Setup" type="always">
+      <t:objective>Create user account</t:objective>
+      <t:steps>1. Login to admin.
+               2. Create test accounts</t:steps>
+      <t:test id="admin_login" required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+               <name>${admin.user}</name>
+               <password>${admin.password}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+      <t:test id="create_testAccount1" required="true">
+         <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+               <name>${test_account1.name}</name>
+               <password>${defaultpassword.value}</password>
+            </CreateAccountRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="name" set="account.name" />
+         </t:response>
+      </t:test>
+      <t:test id="create_testAccount2" required="true">
+         <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+               <name>${account1.name}</name>
+               <password>${account1.password}</password>
+               <a n="zimbraFeatureResetPasswordStatus">enabled</a>
+               <a n="zimbraPrefPasswordRecoveryAddress">${account.name}</a>
+               <a n="zimbraPrefPasswordRecoveryAddressStatus">verified</a>
+            </CreateAccountRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="name" set="resetaccount.name" />
+            <t:select path="//admin:CreateAccountResponse/admin:account/admin:a[@n=&quot;zimbraMailHost&quot;]" set="account1.server" />
+         </t:response>
+      </t:test>
+   </t:test_case>
+
+   <t:test_case testcaseid="Reset_Account_Password_Valid" type="smoke" bugids="ZCS-10146">
+      <t:objective>Reset password  from recover link</t:objective>
+      <t:steps>1. Auth request for admin
+                        2. Send RecoverAccountRequest
+                        3. Send ResetAccountPasswordReques
+                        4. Auth with test accout 
+                        5. Search for Reset password email.
+                        4. Validate contents of the email.
+      </t:steps>
+
+      <t:test id="auth_admin_account" required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+               <name>${admin.user}</name>
+               <password>${admin.password}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+      <t:test id="Send RecoverAccountRequest">
+         <t:request>
+            <RecoverAccountRequest xmlns="urn:zimbraMail">
+               <op>sendRecoveryLink</op>
+               <email>${resetaccount.name}</email>
+            </RecoverAccountRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//RecoverAccountResponse" />
+         </t:response>
+      </t:test>
+      <!-- Reset the password for account 1 user -->
+      <t:test id="Send ResetAccountPasswordRequest">
+         <t:request>
+            <ResetAccountPasswordRequest xmlns="urn:zimbraAdmin">
+               <account by="name">${resetaccount.name}</account>
+            </ResetAccountPasswordRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//ResetAccountPasswordResponse" />
+         </t:response>
+      </t:test>
+      <t:test id="auth_testAccount1" required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+               <account by="name">${test_account1.name}</account>
+               <password>${defaultpassword.value}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+      <t:test id="Search for Welcome to Zimbra Cloud email">
+         <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="message">
+               <query>subject: (${Subject_cloud})</query>
+            </SearchRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//mail:SearchResponse/mail:m/mail:su" match="^${Subject_cloud}$" />
+            <t:select path="//mail:SearchResponse/mail:m" attr="id" set="msg.id" />
+         </t:response>
+      </t:test>
+      <t:test id="Get Welcome to Zimbra Cloud message and validate contents">
+         <t:request>
+            <GetMsgRequest xmlns="urn:zimbraMail">
+               <m id="${msg.id}" />
+            </GetMsgRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//mail:GetMsgResponse/mail:m" attr="id" match="${msg.id}" />
+            <t:select path="//mail:GetMsgResponse/mail:m/mail:mp" attr="ct" match="multipart/alternative" />
+	   <t:select path="//mail:GetMsgResponse/mail:m/mail:mp/mail:mp" attr="content" contains="Welcome to Zimbra Cloud!"/>
+         </t:response>
+      </t:test>
+   </t:test_case>
+</t:tests>


### PR DESCRIPTION
I have added soap automation for ResetAccountPasswordRequest  API.
Result:
-------------------FILE INFO---------------------

XML: build/temp/data/soapvalidator/MailClient/ForgetPassword/ResetAccountPassword.xml


-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

AuthRequest                                         542          3            180
CreateAccountRequest                                242          2            121
SearchRequest                                     21139          1          21139
ResetAccountPasswordRequest                         106          1            106
GetMsgRequest                                        73          1             73
RecoverAccountRequest                               262          1            262


-------------------SUMMARY---------------------

PASS 0001   1/1   345ms AuthRequest                     Account_Setup
PASS 0002   1/1   123ms CreateAccountRequest            Account_Setup
PASS 0003   2/2   119ms CreateAccountRequest            Account_Setup
PASS 0004   1/1    97ms AuthRequest                     Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
PASS 0005   1/1   262ms RecoverAccountRequest           Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
PASS 0006   1/1   106ms ResetAccountPasswordRequest     Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
PASS 0007   1/1   100ms AuthRequest                     Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
PASS 0008   4/4 21139ms SearchRequest                   Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
PASS 0009   3/3    73ms GetMsgRequest                   Reset_Account_Password_Valid (Fixed Bug: #ZCS-4802)
