### PR TITLE
Fix Briefcase-DocumentAction related tests

### DIFF
--- a/data/soapvalidator/Briefcase/Briefcase-DocumentAction.xml
+++ b/data/soapvalidator/Briefcase/Briefcase-DocumentAction.xml
@@ -2,10 +2,10 @@
 
 <t:property name="account1.name" value="account1.${TIME}.${COUNTER}@${defaultdomain.name}"/>
 <t:property name="account2.name" value="account2.${TIME}.${COUNTER}@${defaultdomain.name}"/>
-<t:property name="account1.document.textfile" value="${testMailRaw.root}/Contact/contact1.txt"/>
-<t:property name="account1.document.JPGfile" value="${testMailRaw.root}/Contact/Sunset.jpg"/>
-<t:property name="account1.document.pdffile" value="${testMailRaw.root}/email27/pdfAttachment.pdf"/>
-<t:property name="account1.document.csvfile" value="${testMailRaw.root}/Contact/ZContact2.csv"/>
+<t:property name="account1.document.textfile" value="${testMailRaw.root}/contact/contact1.txt"/>
+<t:property name="account1.document.JPGfile" value="${testMailRaw.root}/contact/sunset.jpg"/>
+<t:property name="account1.document.pdffile" value="${testMailRaw.root}/email27/pdfattachment.pdf"/>
+<t:property name="account1.document.csvfile" value="${testMailRaw.root}/contact/zcontact2.csv"/>
 <t:property name="account1.document.htmlfile" value="${testMailRaw.root}/wiki01/basic.html"/>
 
 <t:test_case testcaseid="Briefcase_DocumentAction_Setup" type="always" >
@@ -61,7 +61,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="Briefcase_DocumentAction_01" type="smoke"  >
+<t:test_case testcaseid="Briefcase_DocumentAction_01" type="smoke">
     <t:objective>Verify watch feature for DocumentActionRequest </t:objective>
 
     <t:steps>
@@ -94,7 +94,6 @@
                         <t:select path="//mail:GetFolderResponse/mail:folder/mail:folder[@name='${globals.briefcase}']" attr="id" set="account1.folder.briefcase.id"/>
                 </t:response>
         </t:test>
-
         <t:uploadservlettest>
                 <t:uploadServletRequest>
                         <filename>${account1.document.pdffile}</filename>


### PR DESCRIPTION
/opt/soap/zm-soap-harness/build/temp/data/soapvalidator/Briefcase/Briefcase-DocumentAction.xml
Tests is failing since long time.
At many places file name for attachment are wrong .
Now it is passing. 