### PR TITLE
Verify Total Msg Count Before and After hitting RecalculateMailboxCountsRequest API

### DIFF
--- a/data/soapvalidator/Admin/General/RecalculateMailboxCountsRequest_10391.xml
+++ b/data/soapvalidator/Admin/General/RecalculateMailboxCountsRequest_10391.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:tests xmlns:t="urn:zimbraTestHarness">
+   <t:property name="account1.name" value="acc1.${TIME}.${COUNTER}@${defaultdomain.name}" />
+   <t:property name="account2.name" value="acc2.${TIME}.${COUNTER}@${defaultdomain.name}" />
+   <t:property name="server.zimbraAdmin" value="${zimbraServer.name}" />
+   <t:test_case testcaseid="Ping" type="always">
+      <t:objective>basic system check</t:objective>
+      <t:test required="true">
+         <t:request>
+            <PingRequest xmlns="urn:zimbraAdmin" />
+         </t:request>
+         <t:response>
+            <t:select path="//admin:PingResponse" />
+         </t:response>
+      </t:test>
+   </t:test_case>
+
+   <t:test_case testcaseid="Chk-Msg-Count-After-RecalculateMailboxCountRequest" type="smoke" bugids="ZCS-10391">
+      <t:objective>Verify Total Msg Count Before and After hiting RecalculateMailboxCountsRequest API</t:objective>
+      <t:test required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+               <name>${admin.user}</name>
+               <password>${admin.password}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+
+      <t:test id="create_account1" required="false" depends="admin_login">
+         <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+               <name>${account1.name}</name>
+               <password>${defaultpassword.value}</password>
+            </CreateAccountRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="id" set="account1.id" />
+            <t:select path="//admin:CreateAccountResponse/admin:account/admin:a[@n=&quot;zimbraMailHost&quot;]" set="account1.server" />
+         </t:response>
+      </t:test>
+
+      <t:property name="message1.folder" value="${testMailRaw.root}/email02/" />
+      <t:property name="nonZimbraUser.name" value="test@test.com" />
+      <t:mailinjecttest>
+         <t:lmtpInjectRequest>
+            <foldername>${message1.folder}</foldername>
+            <to>${account1.name}</to>
+            <from>${nonZimbraUser.name}</from>
+            <server>${account1.server}</server>
+         </t:lmtpInjectRequest>
+      </t:mailinjecttest>
+      <t:test required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+               <account by="name">${account1.name}</account>
+               <password>${defaultpassword.value}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+
+      <t:test>
+         <t:request>
+            <GetFolderRequest xmlns="urn:zimbraMail" visible="1" />
+         </t:request>
+         <t:response>
+            <t:select path="//mail:GetFolderResponse/mail:folder[@name='${globals.root}']">
+               <t:select path="mail:folder[@name='${globals.inbox}']">
+                  <t:select attr="n" match="3" />
+               </t:select>
+            </t:select>
+         </t:response>
+      </t:test>
+
+      <t:test required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+               <name>${admin.user}</name>
+               <password>${admin.password}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+
+      <t:test>
+         <t:request>
+            <RecalculateMailboxCountsRequest xmlns="urn:zimbraAdmin">
+               <mbox id="${account1.id}" />
+            </RecalculateMailboxCountsRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//admin:RecalculateMailboxCountsResponse/admin:mbox[@id='${account1.id}']" attr="used" match="^[0-9].*" />
+         </t:response>
+      </t:test>
+
+      <t:test required="true">
+         <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+               <account by="name">${account1.name}</account>
+               <password>${defaultpassword.value}</password>
+            </AuthRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
+         </t:response>
+      </t:test>
+
+      <t:test>
+         <t:request>
+            <GetFolderRequest xmlns="urn:zimbraMail" visible="1" />
+         </t:request>
+         <t:response>
+            <t:select path="//mail:GetFolderResponse/mail:folder[@name='${globals.root}']">
+               <t:select path="mail:folder[@name='${globals.inbox}']">
+                  <t:select attr="n" match="3" />
+               </t:select>
+            </t:select>
+         </t:response>
+      </t:test>
+   </t:test_case>
+</t:tests>

--- a/data/soapvalidator/Admin/General/RecalculateMailboxCountsRequest_10391.xml
+++ b/data/soapvalidator/Admin/General/RecalculateMailboxCountsRequest_10391.xml
@@ -17,6 +17,13 @@
 
    <t:test_case testcaseid="Chk-Msg-Count-After-RecalculateMailboxCountRequest" type="smoke" bugids="ZCS-10391">
       <t:objective>Verify Total Msg Count Before and After hiting RecalculateMailboxCountsRequest API</t:objective>
+      <t:steps> 1. Create test account
+	      2. Inject 3 messages in inbox
+	      3. Hit GetFolderRequest and verify n=3 in inbox
+	      4. Hit RecalculateMailboxCountsRequest
+	      5. Again  Hit GetFolderRequest and verify n=3 in inbox
+      </t:steps>
+
       <t:test required="true">
          <t:request>
             <AuthRequest xmlns="urn:zimbraAdmin">


### PR DESCRIPTION
Added Automation for ZCS-10391.

Result:
-------------------FILE INFO---------------------

XML: build/temp/data/soapvalidator/Admin/General/RecalculateMailboxCountsRequest1.xml


-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

AuthRequest                                         303          4             75
CreateAccountRequest                                127          1            127
PingRequest                                         296          1            296
GetFolderRequest                                    165          2             82
RecalculateMailboxCountsRequest                     137          1            137


-------------------SUMMARY---------------------

PASS 0001   1/1   296ms PingRequest                     Ping
PASS 0002   1/1    66ms AuthRequest                     Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0003   2/2   127ms CreateAccountRequest            Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0004   0/0   343ms MailInjectTest                  Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0005   1/1   111ms AuthRequest                     Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0006   3/3    99ms GetFolderRequest                Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0007   1/1    70ms AuthRequest                     Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0008   1/1   137ms RecalculateMailboxCountsRequest Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0009   1/1    56ms AuthRequest                     Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)
PASS 0010   3/3    66ms GetFolderRequest                Chk-Msg-Count-After-RecalculateMailboxCountRequest (Fixed Bug: #ZCS-10391)


script_parsable:        1       0
[RecalculateMailboxCountsRequest_10391.txt](https://github.com/Zimbra/zm-soap-harness/files/6149840/RecalculateMailboxCountsRequest_10391.txt)
