### PR TITLE
 Removed all forget password related tests from skip file

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -1,7 +1,7 @@
 # BHR suite skipped due to 503 Service Unavailable error - identify suspect from below files and fix.
 build/temp/data/soapvalidator/Auth/Bugs/ZCS-5598.xml
-build/temp/data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
-build/temp/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
+#build/temp/data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
+#build/temp/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
 build/temp/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
 build/temp/data/soapvalidator/Auth/JWT/JWT-ZCS-3258.xml
 build/temp/data/soapvalidator/Auth/JWT/JWT-ZCS-3676.xml

--- a/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
@@ -272,7 +272,7 @@
 		<t:test id="SearchRequest_for_recoveryCode_email">
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail">
-					<query>subject:Reset your ${account1.server} </query>
+					<query>subject:Reset your</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>
@@ -332,7 +332,7 @@
 		<t:test id="SearchRequest_for_recoveryCode_email">
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail">
-					<query>subject:Reset your ${account1.server} </query>
+					<query>subject:Reset your</query>
 				</SearchRequest>
 			</t:request>
 			<t:response>


### PR DESCRIPTION
#build/temp/data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
#build/temp/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
While executing Soap automation these 2 files were skipped previously, due to this we were missing issue mentioned in ZCS-10427.
Now these 2 files are included in run .

See the recent run result.
     [java] Test Cases Executed:6
     [java] Pass:5
     [java] Fail:1
     [java] Script Errors:0
     [java]
     [java] These tests had failures:
     [java]     /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/Auth/ForgetPassword/ZCS-4798.xml
