### PR TITLE
Fixed script issues as mentioned in zcs10396

### DIFF
--- a/data/soapvalidator/Admin/General/FolderRequest.xml
+++ b/data/soapvalidator/Admin/General/FolderRequest.xml
@@ -610,10 +610,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account9.folder.calendar.id}" gt="${grant.usr}" d="${account8.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account9.folder.calendar.id}"/>
+			<e  a="${account8.name}"/>
+			<notes>test notes ${TIME}</notes>
+		</SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>

--- a/data/soapvalidator/Sharing/Bugs/Bug84420.xml
+++ b/data/soapvalidator/Sharing/Bugs/Bug84420.xml
@@ -172,10 +172,11 @@
     
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account1.folder.inbox.id}" gt="${grant.usr}" d="${account2.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account1.folder.inbox.id}"/>
+			<e a="${account2.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>

--- a/data/soapvalidator/Sharing/Bugs/Bug89307.xml
+++ b/data/soapvalidator/Sharing/Bugs/Bug89307.xml
@@ -184,10 +184,11 @@
     
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account1.folder.inbox.id}" gt="${grant.usr}" d="${account2.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account1.folder.inbox.id}"/>
+			<e a="${account2.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>

--- a/data/soapvalidator/Sharing/SendShareNotificationRequest-Basic.xml
+++ b/data/soapvalidator/Sharing/SendShareNotificationRequest-Basic.xml
@@ -281,10 +281,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account2.folder.calendar.id}" gt="${grant.usr}" d="${account1.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account2.folder.calendar.id}"/>
+			<grant  gt="${grant.usr}" d="${account1.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>
@@ -357,7 +358,7 @@
 
 </t:test_case>
 
-<t:test_case testcaseid="SendShareNotificationRequest_Basic_02" type="bhr">
+<t:test_case testcaseid="SendShareNotificationRequest_Basic_02" type="sanity" bugids="10507">
     <t:objective>Verify that SendShareNotificationRequest gives error if folder not shared</t:objective>
      <t:steps>
      1.Login to Account2
@@ -396,9 +397,10 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account2.folder.Briefcase.id}" gt="${grant.usr}" d="${account1.name}"/>
-				<notes>test notes ${TIME}</notes>
+	    <SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account2.folder.calendar.id}"/>
+			<grant  gt="${grant.usr}" d="${account1.name}"/>
+			<notes>test notes ${TIME}</notes>
             </SendShareNotificationRequest>
         </t:request>
         <t:response>
@@ -462,10 +464,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account3.folder.calendar.id}" gt="${grant.grp}" d="${dl1.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account3.folder.calendar.id}"/>
+			<grant  gt="${grant.grp}" d="${dl1.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>
@@ -653,10 +656,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account3.folder.Briefcase.id}" gt="${grant.grp}" d="${dl1.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account3.folder.Briefcase.id}"/>
+			<grant  gt="${grant.grp}" d="${dl1.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>
@@ -769,10 +773,11 @@
 
 	<t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account3.folder.Briefcase.id}" gt="${grant.grp}" d="${dl1.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account3.folder.Briefcase.id}"/>
+			<grant  gt="${grant.grp}" d="${dl1.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>
@@ -897,10 +902,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account5.folder.calendar.id}" gt="${grant.grp}" d="${dl2.name}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account5.folder.calendar.id}"/>
+			<grant  gt="${grant.grp}" d="${dl2.name}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path="//mail:SendShareNotificationResponse"/>
@@ -1000,10 +1006,11 @@
 
     <t:test >
         <t:request>
-            <SendShareNotificationRequest xmlns="urn:zimbraMail">
-                <share l="${account5.folder.calendar.id}" gt="${grant.grp}" zid="${dl2.id}"/>
-				<notes>test notes ${TIME}</notes>
-            </SendShareNotificationRequest>
+		<SendShareNotificationRequest xmlns="urn:zimbraMail">
+			<item id="${account5.folder.calendar.id}"/>
+			<grant  gt="${grant.grp}" zid="${dl2.id}"/>
+			<notes>test notes ${TIME}</notes>
+                </SendShareNotificationRequest>
         </t:request>
         <t:response>
             <t:select path = "//zimbra:Code" match="^service.INVALID_REQUEST"/>


### PR DESCRIPTION
Fixed script issues regarding SendShareNotificationRequest.
Previously request looks like (Zimbra 9 still support this request)

```
<SendShareNotificationRequest>
 <share [l="{folder-id}"] [path="{fully-qualified-path}"]
 gt="{grantee-type}" [zid="{grantee-id}"] [d="{grantee-display-name}"]/>
 <notes>{notes}</notes>
</SendShareNotificationRequest>
```

It'll be changed to: (On zimbra cloud it shows like )
```
<SendShareNotificationRequest>
 <item id="{item-id}"/>
<e a="{email-addr}"/>
<notes>{notes}</notes>
</SendShareNotificationRequest>```



```
Run-SoapTestCore:
     [echo] STAF: Executing build/temp/data/soapvalidator/temp/  -t smoke 
     [java] 22 Apr 2021 15:09:10,915 [util.Log][main] :: WARN   local config file `/opt/zimbra/conf/localconfig.xml' is not readable   
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/temp/Bug84420.xml
     [java] 
     [java] REQUEST/RESPONSE Results: 18(PASS) - 0(Fail)
     [java] 
     [java] 
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/temp/Bug89307.xml
     [java] 
     [java] REQUEST/RESPONSE Results: 19(PASS) - 0(Fail)
     [java] 
     [java] 
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/temp/FolderRequest.xml
     [java] 
     [java] REQUEST/RESPONSE Results: 50(PASS) - 0(Fail)
     [java] 
     [java] 
     [java] ***************************************************************************************
     [java] EXECUTING TEST: /opt/soap/zm-soap-harness/build/temp/data/soapvalidator/temp/SendShareNotificationRequest-Basic.xml
     [java] 
     [java] REQUEST/RESPONSE Results: 22(PASS) - 0(Fail)
     [java] 
     [java] 
     [java] Tests Executed:109
     [java] Pass:109
     [java] Fail:0
     [java] 
     [java] Test Cases Executed:11
     [java] Pass:11
     [java] Fail:0
     [java] Script Errors:0
     [java] 
     [java] Tests Rerun Executed:0
     [java] Pass:0
     [java] Fail:0
     [java] 
     [java] Test Cases Executed:0
     [java] Pass:0
     [java] Fail:0
     [java] Script Errors:0
     [java] 
     [java] 
     [java] 
     [java] Test finished: PASS

BUILD SUCCESSFUL
Total time: 1 minute 1 second
```

