### PR TITLE
Fixed skipped and failure tests

### DIFF
--- a/data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
+++ b/data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
@@ -120,8 +120,8 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="Reset_Password_Invalid" type="bhr"
-		bugids="ZCS-4802">
+	<t:test_case testcaseid="Reset_Password_Invalid" type="functional"
+		bugids="ZCS-10501">
 		<t:objective>Reset password based on auth token for empty password
 		</t:objective>
 

--- a/data/soapvalidator/Mail/Bugs/Bug70165.xml
+++ b/data/soapvalidator/Mail/Bugs/Bug70165.xml
@@ -90,7 +90,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="bug70165_2" type="bhr">
+<t:test_case testcaseid="bug70165_2" type="functional">
     <t:objective>Verify CheckSpellingRequest is working with a non existing word</t:objective>
     <t:steps>1. Log as user say user1
     		 2. Send CheckSpelling of any word and verify error not returned in CheckSpellingResponse

--- a/data/soapvalidator/Mail/Bugs/Bug97339.xml
+++ b/data/soapvalidator/Mail/Bugs/Bug97339.xml
@@ -102,7 +102,7 @@
 	<t:test>
 	 <t:request>
 	   <SearchRequest xmlns="urn:zimbraMail" types="message">
-	   <query>subject:testing images with / without base</query>
+	   <query>subject:"testing images with / without base"</query>
 	   </SearchRequest>
 	 </t:request>
 	  <t:response>

--- a/data/soapvalidator/Mail/LMTP/AOL/AOL-MIME-Basic.xml
+++ b/data/soapvalidator/Mail/LMTP/AOL/AOL-MIME-Basic.xml
@@ -148,7 +148,7 @@
         </t:request>
         <t:response>
 	       <t:select path="//mail:GetMsgResponse/mail:m[@id='${msg1.id}']">
-          	<t:select path="//mail:mp[@ct='text/html']" attr="content" match="(?s).*This is a basic test mail from AOL and timezone \(\+4:30\)Kabul dated 23rd November 2006\..*"/>
+          	<t:select path="//mail:mp[@ct='text/html']" attr="content" contains="(?s).*This is a basic test mail from AOL and timezone \(\+4:30\)Kabul dated 23rd November 2006\..*"/>
 		   </t:select>
         </t:response>
     </t:test> 
@@ -273,7 +273,7 @@
         </t:request>
         <t:response>
 			<t:select path="//mail:GetMsgResponse/mail:m[@id='${msg3.id}']">
-          	<t:select path="//mail:mp[@ct='text/html']" attr="content" match="(?s).*This is a test message with HTML attachment from AOL and timezone \(\+8:00\) Perth dated 23rd November 2006\..*"/>
+          	<t:select path="//mail:mp[@ct='text/html']" attr="content" contains="(?s).*This is a test message with HTML attachment from AOL and timezone \(\+8:00\) Perth dated 23rd November 2006\..*"/>
 			</t:select>
         </t:response>
     </t:test> 

--- a/data/soapvalidator/Prefs/Identities/Assign-Identity.xml
+++ b/data/soapvalidator/Prefs/Identities/Assign-Identity.xml
@@ -340,7 +340,7 @@
 				<t:select path="//acct:AuthResponse/acct:authToken" set="authToken" />
 			</t:response>
 		</t:test>
-		<t:delay sec="2"/>
+		<t:delay sec="30"/>
 		<t:test>
 			<t:request>
 				<SearchRequest xmlns="urn:zimbraMail" types="message">

--- a/data/soapvalidator/Prefs/Identities/Attachment-Identity.xml
+++ b/data/soapvalidator/Prefs/Identities/Attachment-Identity.xml
@@ -215,7 +215,7 @@
             </t:request>
             <t:response>
                 <t:select
-                    path="//mail:GetMsgResponse//mail:mp" attr="filename" match="textAttachment.txt" />
+                    path="//mail:GetMsgResponse//mail:mp" attr="filename" match="textattachment.txt" />
             </t:response>
         </t:test>
     </t:test_case>

--- a/data/soapvalidator/Search/Bugs/Bug62605.xml
+++ b/data/soapvalidator/Search/Bugs/Bug62605.xml
@@ -88,7 +88,8 @@
 				<server>${account1.server}</server>
         	</t:lmtpInjectRequest>
     	</t:mailinjecttest> 
-		 
+		
+		<t:delay sec="30"/>	
 		<t:property name="server.zimbraAccount" value="${account1.server}"/>
 		<t:test>
 			<t:request>


### PR DESCRIPTION
Fixed following tests from BHR.
```
data/soapvalidator/Auth/ForgetPassword/ResetPassword-ZCS-4802.xml
data/soapvalidator/Mail/Bugs/Bug70165.xml
data/soapvalidator/Mail/Bugs/Bug97339.xml
data/soapvalidator/Mail/LMTP/AOL/AOL-MIME-Basic.xml
data/soapvalidator/Prefs/Identities/Assign-Identity.xml
data/soapvalidator/Prefs/Identities/Attachment-Identity.xml
data/soapvalidator/Search/Bugs/Bug62605.xml
```