### PR TITLE
ZCS-10693: Sieve soap testcase fixes

### DIFF
--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1850.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-1850.xml
@@ -63,6 +63,7 @@ deleteheader :index 1 "X-Header" "Test";
             <t:request>
                 <CreateCosRequest xmlns="urn:zimbraAdmin">
                     <name xmlns="">${cos1.name}</name>
+                    <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
                 </CreateCosRequest>
             </t:request>
             <t:response>
@@ -70,18 +71,6 @@ deleteheader :index 1 "X-Header" "Test";
                 <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cos1.id" />
             </t:response>
         </t:test>
-
-	    <t:test>
-	        <t:request>
-	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
-	                <id>${cos1.id}</id>
-	                <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
-	            </ModifyCosRequest>
-	        </t:request>
-	        <t:response>
-	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
-	        </t:response>
-	    </t:test>
 	    	    		
 		<t:test required="true">
 			<t:request>
@@ -270,7 +259,7 @@ deleteheader :index 1 "X-Header" "Test";
 		</t:resttest>
 </t:test_case>
 
-<t:test_case testcaseid="ZCS-1850_rule2" type="bhr" bugids="ZCS-1850">
+<t:test_case testcaseid="ZCS-1850_rule2" type="functional" bugids="ZCS-1850">
 		<t:objective>Verify header cannot be deleted if any header is added in COS's immutable list</t:objective>
 		<t:steps>			
 			1. add header to COS's immutable list
@@ -363,7 +352,7 @@ deleteheader :index 1 "X-Header" "Test";
 		</t:resttest>
 </t:test_case>
 
-<t:test_case testcaseid="ZCS-1850_rule3" type="bhr" bugids="ZCS-1850">
+<t:test_case testcaseid="ZCS-1850_rule3" type="functional" bugids="ZCS-1850">
 		<t:objective>Verify header cannot be deleted if any header is added in domain's immutable list</t:objective>
 		<t:steps>			
 			1. add header to domain's immutable list
@@ -558,7 +547,7 @@ deleteheader :index 1 "X-Header" "Test";
 		</t:resttest>
 </t:test_case>
 
-    <t:finally type="always">
+    <!--<t:finally type="always">
         <t:objective>reset cosconfig to default </t:objective>
         
         <t:test required="true">
@@ -606,5 +595,5 @@ deleteheader :index 1 "X-Header" "Test";
 	        </t:response>
 	    </t:test>
 	    		
-    </t:finally> 
+    </t:finally>-->
 </t:tests>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-860-EditHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-860-EditHeader.xml
@@ -20,6 +20,7 @@
 	<t:property name="subject11" value="sub11.${TIME}${COUNTER}" />
 	<t:property name="subject12" value="sub12.${TIME}${COUNTER}" />
 	<t:property name="subject13" value="sub13.${TIME}${COUNTER}" />
+        <t:property name="cos.name" value="cos-zcs-860${TIME}${COUNTER}" />
 
 	<t:property name="sieve_test1"
 		value='require ["tag","editheader"];
@@ -155,7 +156,7 @@
 			</t:response>
 		</t:test>
 
-	    <t:test>
+	    <!--<t:test>
 	        <t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
@@ -177,13 +178,28 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
+	    </t:test>-->
+
+
+    <t:test id="CreateCosRequest1">
+        <t:request>
+            <CreateCosRequest xmlns="urn:zimbraAdmin">
+                <name xmlns="">${cos.name}</name>
+                 <a n="zimbraSieveEditHeaderEnabled">TRUE</a>
+            </CreateCosRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="name" match="${cos.name}" />
+            <t:select path="//admin:CreateCosResponse/admin:cos" attr="id" set="cosid" />
+        </t:response>
+    </t:test>
 	    
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">
 					<name>${account1.name}</name>
 					<password>${defaultpassword.value}</password>
+                                        <a n="zimbraCOSId">${cosid}</a>
 				</CreateAccountRequest>
 			</t:request>
 			<t:response>


### PR DESCRIPTION
Fixed tests in ZCS-1850.xml and ZCS-860-EditHeader.xml
Created new cos with zimbraSieveEditHeaderEnabled=TRUE and used in tests. 
Marked ZCS-1850_rule2 and ZCS-1850_rule3 tests as functional - cos/domain modification will not be updated on both mailbox pods immediately.
