### PR TITLE
Added test case for search contact which having single quotes in it

### DIFF
--- a/data/soapvalidator/Search/Contacts/Search-Contact-10799.xml
+++ b/data/soapvalidator/Search/Contacts/Search-Contact-10799.xml
@@ -1,0 +1,140 @@
+<t:tests xmlns:t="urn:zimbraTestHarness">
+<t:property name="test_account.name" value="test.${TIME}.${COUNTER}@${defaultdomain.name}"/>
+<t:property name="test_account.password" value="${defaultpassword.value}"/>
+<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
+
+<t:test_case testcaseid="Ping" type="always" >
+    <t:objective>basic system check</t:objective>
+
+    <t:test required="true">
+        <t:request>
+            <PingRequest xmlns="urn:zimbraAdmin"/>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:PingResponse"/>
+        </t:response>
+    </t:test>
+    
+</t:test_case>
+
+
+<t:test_case testcaseid="admin_auth" type="always" >
+    <t:objective>Login as the admin and create a test account</t:objective>
+    <t:steps>1. Login to admin
+             2. Create a test account
+    </t:steps>
+    
+    <t:test required="true" >
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAdmin">
+                <name>${admin.user}</name>
+                <password>${admin.password}</password>
+             </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:AuthResponse/admin:authToken" set="authToken"/>
+        </t:response>
+    </t:test>
+    
+    <t:test required="true">
+        <t:request>
+            <CreateAccountRequest xmlns="urn:zimbraAdmin">
+                <name>${test_account.name}</name>
+                <password>${test_account.password}</password>
+            </CreateAccountRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//admin:CreateAccountResponse/admin:account" attr="id"  set="test_accountid.id"/>
+            <t:select path='//admin:CreateAccountResponse/admin:account/admin:a[@n="zimbraMailHost"]' set="test_acct.server"/>
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+
+<t:property name="server.zimbraAccount" value="${test_acct.server}"/>
+
+<t:test_case testcaseid="account_login" type="always" >
+    <t:objective>Login as the test account</t:objective>
+
+    <t:test required="true">
+        <t:request>
+            <AuthRequest xmlns="urn:zimbraAccount">
+                <account by="name">${test_account.name}</account>
+                <password>${test_account.password}</password>
+            </AuthRequest>
+        </t:request>
+        <t:response>
+            <t:select path="//acct:AuthResponse/acct:lifetime"  match="^\d+$"/>
+            <t:select path="//acct:AuthResponse/acct:authToken" set="authToken"/>
+
+        </t:response>
+    </t:test>
+
+</t:test_case>
+
+
+<t:test_case testcaseid="account_setup" type="always" >
+    <t:objective>Create contacts with single quotes in FirstName,LastName and emailId for  search </t:objective>
+
+    
+    <t:test id="createContactRequest3">
+        <t:request>
+            <CreateContactRequest xmlns="urn:zimbraMail">
+                <cn>
+                    <a n="firstName">D'Amico</a>
+                    <a n="lastName">D'Last</a>
+                    <a n="email">D'Amico@zmc.com</a>
+                </cn>     
+            </CreateContactRequest>
+         </t:request>
+         <t:response>
+            <t:select path="//mail:CreateContactResponse/mail:cn">
+            <t:select attr="id" set="contact.id1"/>
+            </t:select>    
+        </t:response>
+    </t:test>
+    
+</t:test_case>
+
+
+<t:test_case testcaseid="search_contact1" type="smoke" bugids="10799">
+    <t:objective>Searching with (FirstName\Lastname\EmailId) </t:objective>
+        
+    <t:test>
+        <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="contact">
+                <query>D'Amico</query>
+            </SearchRequest>        
+        </t:request>
+        <t:response>
+            <t:select path="//mail:SearchResponse/mail:cn[@id='${contact.id1}']"/>
+        </t:response>
+    </t:test>
+    
+    <t:test>
+        <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="contact">
+                <query>D'Amico@zmc.com</query>
+            </SearchRequest>        
+        </t:request>
+        <t:response>
+		<t:select path="//mail:SearchResponse/mail:cn[@id='${contact.id1}']"/>
+        </t:response>
+    </t:test>
+
+    <t:test>
+        <t:request>
+            <SearchRequest xmlns="urn:zimbraMail" types="contact">
+                <query>D'Last</query>
+            </SearchRequest>
+        </t:request>
+        <t:response>
+                <t:select path="//mail:SearchResponse/mail:cn[@id='${contact.id1}']"/>
+        </t:response>
+    </t:test>
+
+        
+</t:test_case>
+
+</t:tests>


### PR DESCRIPTION
Issue:
Search is broken when contact having single quotes in FirstName/LastName/EmailId.

This issue has been fixed now and added automated test case for the same issue