### PR TITLE
ZCS-11635: Fixed Sieve tests that were failing due to attributes not getting set 

### DIFF
--- a/data/soapvalidator/Prefs/Filters/Sieve/Bug106349.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/Bug106349.xml
@@ -193,7 +193,7 @@ if header :contains "subject" "${variable_name_dollar_sub}" {
     </t:test_case>
 
     <t:test_case testcaseid="SendMail_And_checkFilter_Execution_2"
-        type="always">
+        type="functional">
         <t:objective> Send test mail
         </t:objective>
         <!-- test 2 -->
@@ -254,7 +254,7 @@ if header :contains "subject" "${variable_name_dollar_sub}" {
     </t:test_case>
 
     <t:test_case testcaseid="SendMail_And_checkFilter_Execution_3"
-        type="always">
+        type="functional">
         <t:objective> Modify zimbraMailSieveScript and run test
         </t:objective>
         <!-- test 3 -->
@@ -411,7 +411,7 @@ if header :contains "subject" "${variable_name_dollar_sub}" {
     </t:test_case>
 
     <t:test_case testcaseid="SendMail_And_checkFilter_Execution_5"
-        type="always">
+        type="functional">
         <t:objective> Modify zimbraMailSieveScript and run test
         </t:objective>
         <!-- test 5 -->

--- a/data/soapvalidator/Prefs/Filters/Sieve/EditHeader-Shared-And-Cloned.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/EditHeader-Shared-And-Cloned.xml
@@ -64,14 +64,10 @@
 </t:test_case>
 
 <!-- Create accounts for testing -->
-<t:test_case testcaseid="CreateAccounts" type="functional">
-	<t:objective>create accounts</t:objective>
-		<t:steps>
-			1. Auth with admin
-			2. create accounts
-		</t:steps>
+<t:test_case testcaseid="ModifyCOS" type="always">
+	<t:objective>Modify COS</t:objective>
 		
-		<t:test required="true">
+	<t:test required="true">
             <t:request>
                 <AuthRequest xmlns="urn:zimbraAdmin">
                     <name>${admin.user}</name>
@@ -81,10 +77,10 @@
             <t:response>
                 <t:select path="//admin:AuthResponse/admin:authToken" set="authToken" />
             </t:response>
-		</t:test>
+	</t:test>
 		
-		<t:test>
-	        <t:request xmlns="urn:zimbraAdmin">
+	<t:test>
+		<t:request xmlns="urn:zimbraAdmin">
 	            <GetCosRequest>
 	                <cos by="name">default</cos>
 	            </GetCosRequest>
@@ -93,9 +89,9 @@
 	            <t:select path="//admin:GetCosResponse/admin:cos" attr="name" match="default"/>
 	            <t:select path="//admin:GetCosResponse/admin:cos" attr="id" set="cosid"/>
 	        </t:response>
-	    </t:test>
+	</t:test>
 
-	    <t:test>
+	<t:test>
 	        <t:request>
 	            <ModifyCosRequest xmlns="urn:zimbraAdmin">
 	                <id>${cosid}</id>
@@ -105,8 +101,16 @@
 	        <t:response>
 	            <t:select path="//admin:ModifyCosResponse/admin:cos"/>            
 	        </t:response>
-	    </t:test>
-		
+	</t:test>
+</t:test_case>
+
+<t:test_case testcaseid="CreateAccounts" type="functional">
+        <t:objective>create accounts</t:objective>
+                <t:steps>
+                        1. Auth with admin
+                        2. create accounts
+		</t:steps>
+
 		<t:test required="true">
 			<t:request>
 				<CreateAccountRequest xmlns="urn:zimbraAdmin">

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-500.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-500.xml
@@ -43,7 +43,7 @@
   </t:test>
  </t:test_case>
 
- <t:test_case testcaseid="CreateDomainRequest0" type="functional">
+ <t:test_case testcaseid="CreateDomainRequest0" type="always">
   <t:objective>create a Domain  </t:objective>
   <t:steps>
    1. Create a new Domain
@@ -62,7 +62,7 @@
   </t:test>
  </t:test_case>
 
- <t:test_case testcaseid="CreateCosRequest1" type="functional">
+ <t:test_case testcaseid="CreateCosRequest1" type="always">
   <t:objective> Create a COS with valid name </t:objective>
   <t:test id="CreateCosRequest1a">
    <t:request>
@@ -79,7 +79,7 @@
   </t:test>
  </t:test_case>
 
- <t:test_case testcaseid="GetAllServerRequest" type="functional">
+ <t:test_case testcaseid="GetAllServerRequest" type="always">
   <t:objective> Get the details of all the servers </t:objective>
   <t:test>
    <t:request>
@@ -1840,7 +1840,7 @@
  </t:test_case>
 
 
- <t:finally>
+ <t:finally type="always">
   <t:test id="admin_login" required="true">
    <t:request>
     <AuthRequest xmlns="urn:zimbraAdmin">

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-842.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-842.xml
@@ -114,7 +114,7 @@ tag "${1}";
 }
 ' />
 
-	<t:test_case testcaseid="AcctSetup1_Sieve" type="functional"
+	<t:test_case testcaseid="AcctSetup1_Sieve" type="always"
 		bugids="zcs873">
 		<t:objective> Accounts setup
 		</t:objective>

--- a/data/soapvalidator/Prefs/Filters/Sieve/ZCS-860-EditHeader.xml
+++ b/data/soapvalidator/Prefs/Filters/Sieve/ZCS-860-EditHeader.xml
@@ -139,7 +139,7 @@
 	' />
 
 
-	<t:test_case testcaseid="AcctSetup1_ZCS-860" type="functional"
+	<t:test_case testcaseid="AcctSetup1_ZCS-860" type="always"
 		bugids="zcs860">
 		<t:objective> Create test account and login to first account
 		</t:objective>


### PR DESCRIPTION
Fixed tests that were failing or throwing exception due to setup test cases being skipped and not setting attributes that were referenced in finally block.