### PR TITLE
ZCS-14392:Fix Soap harness failures in execution on OCI VM

### DIFF
--- a/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
+++ b/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
@@ -150,8 +150,8 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs_2478SendMsg_02" type="deprecated"
-		bugsids="zcs-2478" >
+	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr-tbd"
+		bugsids="zcs-2478,ZCS-8050" >
 		<t:objective>Invalidate a JWT session using EndSessionRequest and send
 			a soap request
 		</t:objective>
@@ -442,8 +442,8 @@
 	</t:test_case>
 
 
-	<t:test_case testcaseid="zcs2478_TC_06" type="deprecated"
-		bugsids="zcs-2478">
+	<t:test_case testcaseid="zcs2478_TC_06" type="bhr-tbd"
+		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>
 		<t:steps>1. User 1 generates a JWT token.
@@ -522,8 +522,8 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs2478_TC_07" type="deprecated"
-		bugsids="zcs-2478">
+	<t:test_case testcaseid="zcs2478_TC_07" type="bhr-tbd"
+		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>
 		<t:steps>1. User 1 generates three JWT tokens.

--- a/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
+++ b/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
@@ -150,8 +150,8 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr"
-		bugsids="zcs-2478">
+	<t:test_case testcaseid="zcs_2478SendMsg_02" type="deprecated"
+		bugsids="zcs-2478" >
 		<t:objective>Invalidate a JWT session using EndSessionRequest and send
 			a soap request
 		</t:objective>
@@ -205,6 +205,7 @@
 				<t:select path="//soap:Text" match="no valid authtoken present" />
 			</t:response>
 		</t:test>
+		
 
 		<t:test>
 			<t:requestContext>
@@ -441,7 +442,7 @@
 	</t:test_case>
 
 
-	<t:test_case testcaseid="zcs2478_TC_06" type="bhr"
+	<t:test_case testcaseid="zcs2478_TC_06" type="deprecated"
 		bugsids="zcs-2478">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>
@@ -521,7 +522,7 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs2478_TC_07" type="bhr"
+	<t:test_case testcaseid="zcs2478_TC_07" type="deprecated"
 		bugsids="zcs-2478">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>

--- a/data/soapvalidator/Contacts/Contact-Modify-Group-Ref.xml
+++ b/data/soapvalidator/Contacts/Contact-Modify-Group-Ref.xml
@@ -258,6 +258,7 @@
                <cn id="${contact_group.id}">
                     <a n="type">group</a>
                     <m op="+" type="C" value="${contact_ref1.id}"/>
+                    <m op="-" type="I" value="${contact2.mailid}"/>
                </cn>     
             </ModifyContactRequest>
         </t:request>

--- a/data/soapvalidator/Folders/Bugs/Bug31113.xml
+++ b/data/soapvalidator/Folders/Bugs/Bug31113.xml
@@ -268,7 +268,7 @@
 		<t:response>
 			<t:select path="//mail:SaveDocumentResponse/mail:doc" >
 				<t:select attr="id" set="doc.id" />
-				<t:select attr="name" match="Goals.doc" />
+				<t:select attr="name" match="goals.doc" />
 			</t:select>	
 		</t:response>
 	</t:test>


### PR DESCRIPTION
**Fixed below test cases:**
/opt/qa/soapvalidator/data/soapvalidator/Contacts/Contact-Modify-Group-Ref.xml --> Fixed request in test case
/opt/qa/soapvalidator/data/soapvalidator/Folders/Bugs/Bug31113.xml --> Fixed file name in test case
/opt/qa/soapvalidator/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml --> deprecated failing test cases because of open issue

**`XML: C:\soap\zm-soap-harness\data\soapvalidator\Folders\Bugs\Bug31113.xml**


-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

AuthRequest                                         216          3             72
CreateAccountRequest                               5439          2           2719
SearchRequest                                       291          1            291
PingRequest                                         178          1            178
GetFolderRequest                                    353          1            353
CreateMountpointRequest                              49          1             49
FolderActionRequest                                  56          1             56
GetMsgRequest                                        59          1             59
SaveDocumentRequest                                 116          1            116
SendMsgRequest                                      185          1            185
CreateFolderRequest                                 465          1            465


-------------------SUMMARY---------------------

PASS 0001   1/1   178ms PingRequest                 	Ping
PASS 0002   1/1    61ms AuthRequest                 	acctSetup1_CreateMountpoint
PASS 0003   2/2  5330ms CreateAccountRequest        	acctSetup1_CreateMountpoint
PASS 0004   2/2   109ms CreateAccountRequest        	acctSetup1_CreateMountpoint
PASS 0005   2/2    65ms AuthRequest                 	acctSetup1_CreateMountpoint
PASS 0006   2/2    90ms AuthRequest                 	acctSetup1_CreateMountpoint
PASS 0007   4/4   353ms GetFolderRequest            	acctSetup1_CreateMountpoint
PASS 0008   1/1   465ms CreateFolderRequest         	shareFolderAttSave
PASS 0009   1/1    56ms FolderActionRequest         	shareFolderAttSave
PASS 0010   1/1   469ms UploadServletTest           	shareFolderAttSave
PASS 0011   1/1   185ms SendMsgRequest              	shareFolderAttSave
PASS 0012   1/1    49ms CreateMountpointRequest     	shareFolderAttSave
PASS 0013   1/1   291ms SearchRequest               	shareFolderAttSave
PASS 0014   1/1    59ms GetMsgRequest               	shareFolderAttSave
PASS 0015   3/3   116ms SaveDocumentRequest         	shareFolderAttSave


script_parsable:	0	0



TEST CASE Results: 0(PASS) - 0(Fail)


REQUEST/RESPONSE Results: 15(PASS) - 0(Fail)`

**`XML: C:\soap\zm-soap-harness\data\soapvalidator\Contacts\Contact-Modify-Group-Ref.xml**


-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

CreateContactRequest                                436          3            145
AuthRequest                                         261          4             65
CreateAccountRequest                               4545          3           1515
PingRequest                                         158          1            158
ModifyContactRequest                                124          2             62


-------------------SUMMARY---------------------

PASS 0001   1/1   158ms PingRequest                 	Ping
PASS 0002   1/1    78ms AuthRequest                 	ModifyContacts_Group_Reference_acctsetup1
PASS 0003   2/2  4347ms CreateAccountRequest        	ModifyContacts_Group_Reference_acctsetup1
PASS 0004   2/2    93ms CreateAccountRequest        	ModifyContacts_Group_Reference_acctsetup1
PASS 0005   2/2   105ms CreateAccountRequest        	ModifyContacts_Group_Reference_acctsetup1
PASS 0006   2/2    73ms AuthRequest                 	ModifyContacts_Group_Reference_acctsetup2
PASS 0007   1/1  1143ms StafTaskTest                	ModifyContacts_Group_Reference_acctsetup2
PASS 0008   1/1  1137ms StafTaskTest                	ModifyContacts_Group_Reference_acctsetup2
PASS 0009   2/2   291ms CreateContactRequest        	ModifyContacts_Group_Reference_acctsetup2
PASS 0010   5/5    53ms CreateContactRequest        	ModifyContacts_Group_Reference_acctsetup2
SKIP ModifyContacts_Group_Reference_01
PASS 0011   2/2    54ms AuthRequest                 	ModifyContacts_Group_Reference_02
PASS 0012   2/2    92ms CreateContactRequest        	ModifyContacts_Group_Reference_02
PASS 0013   6/6    63ms ModifyContactRequest        	ModifyContacts_Group_Reference_02
PASS 0014   2/2    56ms AuthRequest                 	ModifyContacts_Group_Reference_03
PASS 0015   1/1    61ms ModifyContactRequest        	ModifyContacts_Group_Reference_03


script_parsable:	2	0



TEST CASE Results: 2(PASS) - 0(Fail)
`
**`XML: C:\soap\zm-soap-harness\data\soapvalidator\Auth\JWT\JWT-ZCS-2478.xml**


-----------------------------REQUEST PERFORMANCE SUMMARY---------------------------------

Request Name                              ExecutionTime(msec)  ExecutionCount  AvgExecutionTime(msec)

AuthRequest                                         113          2             56
CreateAccountRequest                               4529          3           1509
PingRequest                                         250          1            250
GetDomainInfoRequest                                 66          1             66
SendMsgRequest                                       52          1             52


-------------------SUMMARY---------------------

PASS 0001   1/1   250ms PingRequest                 	Ping
PASS 0002   1/1    62ms AuthRequest                 	acct1_setup
PASS 0003   1/1    66ms GetDomainInfoRequest        	acct1_setup
PASS 0004   2/2  4318ms CreateAccountRequest        	acct1_setup
PASS 0005   2/2   101ms CreateAccountRequest        	acct1_setup
PASS 0006   2/2   110ms CreateAccountRequest        	acct1_setup
PASS 0007   1/1    51ms AuthRequest                 	zcs2478_TC_01
PASS 0008   2/2    52ms SendMsgRequest              	zcs2478_TC_01
SKIP zcs_2478SendMsg_02
SKIP zcs2478_TC_03
SKIP zcs2478_TC_04
SKIP zcs2478_TC_05
SKIP zcs2478_TC_06
SKIP zcs2478_TC_07


script_parsable:	1	0



TEST CASE Results: 1(PASS) - 0(Fail)


REQUEST/RESPONSE Results: 8(PASS) - 0(Fail)
`