### PR TITLE
ZCS-14594: Fix Soap harness failures in execution on OCI VM

### DIFF
--- a/data/soapvalidator/Search/Bugs/SearchActionRequest-ZCS-3441.xml
+++ b/data/soapvalidator/Search/Bugs/SearchActionRequest-ZCS-3441.xml
@@ -78,7 +78,7 @@
 	</t:test_case>
 
 
-	<t:test_case testcaseid="SearchActionRequest_test1" type="smoke">
+	<t:test_case testcaseid="SearchActionRequest_test1" type="always">
 		<t:objective> Verify SearchAction Request with move action for new
 			folder for single mail</t:objective>
 

--- a/data/soapvalidator/Search/Bugs/SortBy-ZCS-3705.xml
+++ b/data/soapvalidator/Search/Bugs/SortBy-ZCS-3705.xml
@@ -232,8 +232,8 @@
 			</t:response>
 		</t:test>
 	</t:test_case>
-	<t:test_case testcaseid="Verify_Scrolldown_Error" type="bhr"
-		bugids="ZBUG-425, ZBUG-563">
+	<t:test_case testcaseid="Verify_Scrolldown_Error" type="bhr-temp"
+		bugids="ZBUG-425, ZBUG-563, ZCS-7936">
 		<t:objective>To verify no exception is thrown on scrolling to the end
 			of the search results when results are sorted by read/unread
 		</t:objective>

--- a/data/soapvalidator/Search/DelayedIndexing/ZCS-8516.xml
+++ b/data/soapvalidator/Search/DelayedIndexing/ZCS-8516.xml
@@ -18,7 +18,7 @@
     </t:test>
 </t:test_case>
 
-<t:test_case testcaseid="acctSetup" type="always">
+<t:test_case testcaseid="acctSetup" type="deprecated">
     <t:objective>create test accounts</t:objective>
     <t:steps> 1. Login to Admin
               2. Create test accounts
@@ -116,7 +116,7 @@
 
 </t:test_case>
 
-<t:test_case testcaseid="auto_deletion_of_index" type="functional" bugids="ZCS-8516">
+<t:test_case testcaseid="auto_deletion_of_index" type="deprecated" bugids="ZCS-8516">
     <t:objective>Verify that account's indexes are auto-deleted if account is inactive for more than zimbraDelayedIndexInactiveAccountAge duration</t:objective>
     <t:steps>1. Wait for time interval where current time exceeds zimbraDelayedIndexInactiveAccountAge cutoff
              2. Search email in account2 - verify no search results are returned


### PR DESCRIPTION
/opt/qa/soapvalidator/data/soapvalidator/Search/Bugs/SearchActionRequest-ZCS-3441.xml --> Fixed SearchActionRequest_test1 test type to **always** as SearchActionRequest_test2 depends on SearchActionRequest_test1, previously it was smoke

/opt/qa/soapvalidator/data/soapvalidator/Search/Bugs/SortBy-ZCS-3705.xml --> Changed type of test case Verify_Scrolldown_Error to **bhr-temp** as it failing because of long pending open issue **ZCS-7936**

/opt/qa/soapvalidator/data/soapvalidator/Search/DelayedIndexing/ZCS-8516.xml --> Changed type to **deprecated** as zimbraDelayedIndexInactiveAccountAge attribute is not applicable to zimbra 10/9