### PR TITLE
ZCS-14799: Deprecated tests blocking soap execution

### DIFF
--- a/data/soapvalidator/Admin/ExternalStore/VerifyStoreManagerRequest.xml
+++ b/data/soapvalidator/Admin/ExternalStore/VerifyStoreManagerRequest.xml
@@ -4,7 +4,7 @@
 
 <t:property name="zimbra.home.dir" value="/opt/zimbra"/>
 
-<t:test_case testcaseid="VerifyStoreManagerRequest_Setup" type="always" >
+<t:test_case testcaseid="VerifyStoreManagerRequest_Setup" type="deprecated" >
     <t:objective>Test setup</t:objective>
 
 	<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>	
@@ -130,7 +130,7 @@
 <!-- Make sure non-admin auth is not allowed to run tests -->
 
 
-<t:test_case testcaseid="VerifyStoreManagerRequest_01" type="bhr">
+<t:test_case testcaseid="VerifyStoreManagerRequest_01" type="deprecated">
   <t:objective>Make sure user is not allowed to make VerifyStoreManagerRequest</t:objective>
 
 	<t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
@@ -162,7 +162,7 @@
 <!-- Do admin auth and send VerifyStoreManagerRequest  -->
 
 
-<t:test_case testcaseid="VerifyStoreManagerRequest_02" type="bhr">
+<t:test_case testcaseid="VerifyStoreManagerRequest_02" type="deprecated">
     <t:objective>Send VerifyStoreManagerRequest as a admin and check response </t:objective>
 
     <t:test id="admin_login" required="true">

--- a/data/soapvalidator/Auth/CustomAuth/CustomAuth.xml
+++ b/data/soapvalidator/Auth/CustomAuth/CustomAuth.xml
@@ -9,7 +9,7 @@
 
 <t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
 
-<t:test_case testcaseid="Ping" type="always" areas="noncluster">
+<t:test_case testcaseid="Ping" type="deprecated" areas="noncluster">
  <t:objective>basic system check</t:objective>
 
 	<t:test required="true">
@@ -51,7 +51,7 @@
 </t:test_case>
 
 
-<t:test_case testcaseid="acct1_setup" type="always" areas="noncluster">
+<t:test_case testcaseid="acct1_setup" type="deprecated" areas="noncluster">
  <t:objective>create test account</t:objective>
 
 	<t:test required="true" >
@@ -97,7 +97,7 @@
 
 
 
-<t:test_case testcaseid="AuthRequest_CustomAuth_01" type="sanity" areas="noncluster">
+<t:test_case testcaseid="AuthRequest_CustomAuth_01" type="deprecated" areas="noncluster">
 	<t:objective>Verify that a positive authentication results from custom auth extension</t:objective>
 
 
@@ -121,7 +121,7 @@
 
 </t:test_case>
 
-<t:test_case testcaseid="AuthRequest_CustomAuth_02" type="sanity" areas="noncluster">
+<t:test_case testcaseid="AuthRequest_CustomAuth_02" type="deprecated" areas="noncluster">
 	<t:objective>Verify auth failed results from custom auth extension</t:objective>
 
 
@@ -143,7 +143,7 @@
 
 </t:test_case>
 
-<t:test_case testcaseid="AuthRequest_CustomAuth_03" type="sanity" bugids="17889" areas="noncluster">
+<t:test_case testcaseid="AuthRequest_CustomAuth_03" type="deprecated" bugids="17889" areas="noncluster">
 	<t:objective>Verify change password results from custom auth extension</t:objective>
 
 


### PR DESCRIPTION
Few tests used custom jars built with old log4j and caused issues after copy on mailbox server. Deprecated tests till we use updated custom jars.