### PR TITLE
ZCS-14776: Fixed test case type to bhr-temp instead of bhr-tbd

### DIFF
--- a/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
+++ b/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
@@ -150,7 +150,7 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr-tbd"
+	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050" >
 		<t:objective>Invalidate a JWT session using EndSessionRequest and send
 			a soap request
@@ -442,7 +442,7 @@
 	</t:test_case>
 
 
-	<t:test_case testcaseid="zcs2478_TC_06" type="bhr-tbd"
+	<t:test_case testcaseid="zcs2478_TC_06" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>
@@ -522,7 +522,7 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs2478_TC_07" type="bhr-tbd"
+	<t:test_case testcaseid="zcs2478_TC_07" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>


### PR DESCRIPTION
Fixed test case type to "bhr-temp" instead of "bhr-tbd" in data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml