### PR TITLE
ZCS-14776: Fix Soap harness failures in execution on OCI VM

### DIFF
--- a/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
+++ b/data/soapvalidator/Auth/JWT/JWT-ZCS-2478.xml
@@ -150,7 +150,7 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr-tbd"
+	<t:test_case testcaseid="zcs_2478SendMsg_02" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050" >
 		<t:objective>Invalidate a JWT session using EndSessionRequest and send
 			a soap request
@@ -442,7 +442,7 @@
 	</t:test_case>
 
 
-	<t:test_case testcaseid="zcs2478_TC_06" type="bhr-tbd"
+	<t:test_case testcaseid="zcs2478_TC_06" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>
@@ -522,7 +522,7 @@
 
 	</t:test_case>
 
-	<t:test_case testcaseid="zcs2478_TC_07" type="bhr-tbd"
+	<t:test_case testcaseid="zcs2478_TC_07" type="bhr-temp"
 		bugsids="zcs-2478,ZCS-8050">
 		<t:objective>Invalidate a JWT session and send a soap request
 		</t:objective>

--- a/data/soapvalidator/Calendar/Appointments/CancelAppointmentRequest-Basic.xml
+++ b/data/soapvalidator/Calendar/Appointments/CancelAppointmentRequest-Basic.xml
@@ -121,7 +121,7 @@
     <t:objective>Delete Inline event.</t:objective>
 
 
-	<t:property name="time.20071201120000.gmt" value="1196510400000"/>
+	<t:property name="time.20251201120000.gmt" value="1764590400000"/>
    
     <t:test>
         <t:request>
@@ -129,8 +129,8 @@
                 <m>
                     <inv > 
                     	<comp method="REQUEST" type="event" fb="B" transp="O" allDay="0" name="${appointment.subject}" >
-	                        <s d="${ICALTIME[${time.20071201120000.gmt}]}"/>  
-	                        <e d="${ICALTIME(+1h)[${time.20071201120000.gmt}]}"/>  
+	                        <s d="${ICALTIME[${time.20251201120000.gmt}]}"/>  
+	                        <e d="${ICALTIME(+1h)[${time.20251201120000.gmt}]}"/>  
 	                        <or a="${account1.name}"/>
                         </comp>
                     </inv>
@@ -155,7 +155,7 @@
         <t:response>
             <t:select path="//mail:GetMsgResponse/mail:m[@id='${appointment1.id}']">
         		<t:select path="//mail:comp">
-        			<t:select path="//mail:s" attr="d" match="${ICALTIME[${time.20071201120000.gmt}]}"/>
+        			<t:select path="//mail:s" attr="d" contains="${ICALTIME[${time.20251201120000.gmt}]}"/>
             	</t:select>
             </t:select>
         </t:response>
@@ -163,7 +163,7 @@
 
    <t:test>
         <t:request>
-			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20071201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20071201120000.gmt}]}" types="appointment">
+			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20251201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20251201120000.gmt}]}" types="appointment">
 				<query>inid:${account1.calendar.folder.id}</query>
 			</SearchRequest>
         </t:request>
@@ -193,7 +193,7 @@
  
    <t:test>
         <t:request>
-			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20071201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20071201120000.gmt}]}" types="appointment">
+			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20251201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20251201120000.gmt}]}" types="appointment">
 				<query>inid:${account1.calendar.folder.id}</query>
 			</SearchRequest>
         </t:request>

--- a/data/soapvalidator/Calendar/Appointments/CreateAppointmentRequest-Private.xml
+++ b/data/soapvalidator/Calendar/Appointments/CreateAppointmentRequest-Private.xml
@@ -90,7 +90,7 @@
     <t:objective> Create Private calendar - Default.</t:objective>
 
 
-	<t:property name="time.20071201120000.gmt" value="1196510400000"/>
+	<t:property name="time.20251201120000.gmt" value="1764590400000"/>
    
     <t:test>
         <t:request>
@@ -98,8 +98,8 @@
                 <m>
                     <inv > 
                     	<comp method="REQUEST" type="event" fb="B" transp="O" allDay="0" name="${appointment.subject}" class="PRI" >
-	                        <s d="${ICALTIME[${time.20071201120000.gmt}]}"/>  
-	                        <e d="${ICALTIME(+1h)[${time.20071201120000.gmt}]}"/>  
+	                        <s d="${ICALTIME[${time.20251201120000.gmt}]}"/>  
+	                        <e d="${ICALTIME(+1h)[${time.20251201120000.gmt}]}"/>  
 	                        <or a="${account1.name}"/>
                         </comp>
                     </inv>
@@ -124,7 +124,7 @@
         <t:response>
             <t:select path="//mail:GetMsgResponse/mail:m[@id='${appointment1.id}']">
         		<t:select path="//mail:comp">
-        			<t:select path="//mail:s" attr="d" match="${ICALTIME[${time.20071201120000.gmt}]}"/>
+        			<t:select path="//mail:s" attr="d" contains="${ICALTIME[${time.20251201120000.gmt}]}"/>
             	</t:select>
             </t:select>
         </t:response>
@@ -132,7 +132,7 @@
 
    <t:test>
         <t:request>
-			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20071201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20071201120000.gmt}]}" types="appointment">
+			<SearchRequest xmlns="urn:zimbraMail" calExpandInstStart="${TIME(-1d)[${time.20251201120000.gmt}]}" calExpandInstEnd="${TIME(+1d)[${time.20251201120000.gmt}]}" types="appointment">
 				<query>inid:${account1.calendar.folder.id}</query>
 			</SearchRequest>
         </t:request>

--- a/data/soapvalidator/REST/Mail/Post/Basic.xml
+++ b/data/soapvalidator/REST/Mail/Post/Basic.xml
@@ -71,8 +71,8 @@
 </t:test_case>
 
 
-
-<t:test_case testcaseid="RestServlet_MailPost_01" type="bhr">
+<!-- Added bug id for 10.0.X version, it is working on 9.0.0 version -->
+<t:test_case testcaseid="RestServlet_MailPost_01" type="bhr" bugids="ZCS-14808">
 	<t:objective>Post a basic calendar ICS to the REST servlet</t:objective>
 	<t:steps>
 	1. Use the rest servlet to upload a calendar ICS


### PR DESCRIPTION
Fixed below test cases:

- data/soapvalidator/Calendar/Appointments/CreateAppointmentRequest-Private.xml
- data/soapvalidator/Calendar/Appointments/CreateAppointmentRequest-Reminder.xml
Changed time and verification method so that tests will be executed on all timezone

- /opt/qa/soapvalidator/data/soapvalidator/REST/Mail/Post/Basic.xml
Updated bug id in the script
