### PR TITLE
ZCS-14882: Use curl for sending notification emails. Add build info and other details in the email.

### DIFF
--- a/utils/run_and_monitor_soap.sh
+++ b/utils/run_and_monitor_soap.sh
@@ -103,6 +103,9 @@ function check_staf {
 
 function start_staf {
     cd $dir_staf
+    STAF local shutdown shutdown || true
+    old_staf_pid=$(pidof STAFProc)
+    sudo kill -9 $old_staf_pid
     export PATH=$PATH:$dir_staf/bin && \
     export LD_LIBRARY_PATH=$dir_staf/lib
     sudo chmod +wx ./STAFEnv.sh
@@ -190,7 +193,7 @@ function set_properties {
     sudo sed -i "s|@zimbra\.com|@$domain_name|g" $dir_qa/soapvalidator/conf/global.properties
     sudo sed -i "s|defaultdomain\.name=.*|defaultdomain.name=$domain_name|g" $dir_qa/soapvalidator/conf/global.properties
     sudo sed -i "s|admin\.password=.*|admin.password=$ADMIN_PASS|g" $dir_qa/soapvalidator/conf/global.properties
-    sudo sed -i "s|admin\.user=.*|admin.password=$ADMIN_USER|g" $dir_qa/soapvalidator/conf/global.properties
+    sudo sed -i "s|admin\.user=.*|admin.user=$ADMIN_USER|g" $dir_qa/soapvalidator/conf/global.properties
 }
 
 function run_tests {


### PR DESCRIPTION
**ZCS-14882: Use curl for sending notification emails. Add build info and other details in the email.**
- Using curl instead of sendmail command for sending the notification emails
- Added more details about the builds in the emails.
- Using email in HTML format to make it look good in the inbox.
- Resolved incorrect editing of global.properties file.

**Note -**
- Env variables `ENV_MAIL_FROM`, `ENV_MAIL_PASSWORD` and `ENV_SMTP_SERVER` Must be set on the server for Notification emails to be sent out.