### PR TITLE
ZCS-14952: Fixed the failing BHR test cases in master workflow of ZoK

### DIFF
--- a/conf/skipped-tests-zimbrax.txt
+++ b/conf/skipped-tests-zimbrax.txt
@@ -211,3 +211,25 @@ build/temp/data/soapvalidator/Prefs/Filters/Priority/ConversationTest.xml
 build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-500.xml
 # Below tests failing due to Bug# ZCS-10352
 build/temp/data/soapvalidator/Prefs/Filters/Sieve/ZCS-559-EscapeSeq.xml
+
+# Below tests are failing due to ZCS-14652
+build/temp/data/soapvalidator/Admin/DistributionList/Bugs/69486.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Bugs/Bug68891.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Bugs/Bug72791.xml
+build/temp/data/soapvalidator/Admin/DistributionList/DL-SendToDistList.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Add-Remove-Member.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Delete.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Modify.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Owner.xml
+build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Subscribe-Unsuscribe.xml
+build/temp/data/soapvalidator/Admin/DistributionList/GetAccountDistributionListsRequest.xml
+build/temp/data/soapvalidator/Admin/DistributionList/GetDistributionListRequest-Basic.xml
+
+# Below tests are failing because of lower openJDK version in ZoK
+build/temp/data/soapvalidator/General/GetAllLocalesRequest.xml
+
+# Below tests are failing due to Bug# ZCS-14997
+build/temp/data/soapvalidator/Mail/Bugs/Bug30269.xml
+build/temp/data/soapvalidator/Mail/Bugs/Bug30428.xml
+build/temp/data/soapvalidator/Mail/Bugs/Bug30433.xml
+build/temp/data/soapvalidator/Mail/Bugs/Bug54590.xml

--- a/data/soapvalidator/Mail/Persona/SendMailUsingDistributionListPersona.xml
+++ b/data/soapvalidator/Mail/Persona/SendMailUsingDistributionListPersona.xml
@@ -327,7 +327,7 @@
 	 </t:request>
 	  <t:response>
 			<t:select path="//mail:SearchResponse/mail:m/mail:su" match="${msg02.subject}"/>
-			<t:select path="//mail:SearchResponse/mail:m" attr="id" set="msg02.id"/>
+			<t:select path="//mail:SearchResponse/mail:m[1]" attr="id" set="msg02.id"/>
 	 </t:response>
 	</t:test>
 	
@@ -557,5 +557,4 @@
 			</t:select>
 			</t:response>
     </t:test>
-	
 </t:tests>

--- a/data/soapvalidator/Search/Bugs/Bug12539.xml
+++ b/data/soapvalidator/Search/Bugs/Bug12539.xml
@@ -2,7 +2,6 @@
 
 <t:property name="account.name" value="test1${TIME}${COUNTER}@${defaultdomain.name}"/>
 <t:property name="server.zimbraAdmin" value="${zimbraServer.name}"/>
-<t:property name="account.MailHost" value="${zimbraMailHost.name}"/>
 
 <t:test_case testcaseid="Ping" type="always" >
     <t:objective>basic system check</t:objective>
@@ -44,7 +43,6 @@
             <CreateAccountRequest xmlns="urn:zimbraAdmin">
                 <name>${account.name}</name>
                 <password>${defaultpassword.value}</password>
-                <a n="zimbraMailHost">${account.MailHost}</a>
             </CreateAccountRequest>
         </t:request>
         <t:response>

--- a/data/soapvalidator/Search/Bugs/Bug78001.xml
+++ b/data/soapvalidator/Search/Bugs/Bug78001.xml
@@ -180,7 +180,7 @@
 	<t:test >
         <t:request>
 			<SearchRequest xmlns="urn:zimbraMail" types="message">
-				<query>"${search.string}"</query>
+				<query>${search.string} in:Sent to:${test_account.name}</query>
 			</SearchRequest>
 		</t:request>
 		<t:response>


### PR DESCRIPTION
Fixed/Skipped the following test cases which are failing in master workflow of ZoK:

Following tests have been added to skip list as they are failing because of application issues ZCS-14652 and ZCS-14997

`build/temp/data/soapvalidator/Admin/DistributionList/Bugs/69486.xml
build/temp/data/soapvalidator/Admin/DistributionList/Bugs/Bug68891.xml
build/temp/data/soapvalidator/Admin/DistributionList/Bugs/Bug72791.xml
build/temp/data/soapvalidator/Admin/DistributionList/DL-SendToDistList.xml
build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Add-Remove-Member.xml
build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Delete.xml
build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Action-Modify.xml
build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Owner.xml
build/temp/data/soapvalidator/Admin/DistributionList/Distributionlist-Subscribe-Unsuscribe.xml
build/temp/data/soapvalidator/Admin/DistributionList/GetAccountDistributionListsRequest.xml
build/temp/data/soapvalidator/Admin/DistributionList/GetDistributionListRequest-Basic.xml
build/temp/data/soapvalidator/Mail/Bugs/Bug30269.xml 
build/temp/data/soapvalidator/Mail/Bugs/Bug30428.xml 
build/temp/data/soapvalidator/Mail/Bugs/Bug30433.xml 
build/temp/data/soapvalidator/Mail/Bugs/Bug54590.xml`

Following tests have been fixed
`build/temp/data/soapvalidator/Mail/Persona/SendMailUsingDistributionListPersona.xml`
`build/temp/data/soapvalidator/Search/Bugs/Bug12539.xml`
`build/temp/data/soapvalidator/Search/Bugs/Bug78001.xml`
